### PR TITLE
Fix daily intake reset at 4am (Issue #17)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,7 @@
 # Aquavate - Active Development Progress
 
 **Last Updated:** 2026-01-21
-**Current Branch:** `healthkit-integration`
+**Current Branch:** `daily-reset-from-records`
 
 ---
 
@@ -13,6 +13,11 @@
 
 ## Recently Completed
 
+- ✅ Fix Daily Intake Reset at 4am (Issue #17) - [Plan 031](Plans/031-daily-reset-from-records.md)
+  - Removed redundant cached fields from DailyState struct
+  - Daily totals now computed dynamically from drink records using 4am boundary
+  - Matches iOS app calculation logic for consistency
+  - Removed deprecated SET_DAILY_INTAKE command
 - ✅ Shake-to-Empty Improvements - [Plan 030](Plans/030-shake-to-empty-improvements.md)
   - Fixed extended sleep lockout when shaking to empty
   - Extended sleep timer now resets on user interactions (shake, drink, stable)
@@ -37,7 +42,7 @@
 
 ## Branch Status
 
-- `healthkit-integration` - **ACTIVE**: Ready for next task
+- `daily-reset-from-records` - **ACTIVE**: Ready for PR
 - `swipe-to-delete-drinks` - Ready to merge
 - `master` - Stable baseline
 

--- a/Plans/031-daily-reset-from-records.md
+++ b/Plans/031-daily-reset-from-records.md
@@ -1,0 +1,81 @@
+# Plan: Fix Daily Intake Reset at 4am (Issue #17)
+
+**Status:** ✅ COMPLETE (2026-01-21)
+
+## Problem Summary
+
+The bottle's daily intake total is not resetting correctly at 4am. The iOS app shows the correct total (drinks from 4am onwards), but the bottle shows a higher total because it includes drinks from before 4am.
+
+## Root Cause
+
+The `daily_total_ml` and `drink_count_today` are stored as accumulated values in NVS. When the bottle boots, it loads these stale values instead of computing them from actual drink records.
+
+## Solution: Full Cleanup
+
+Remove redundant cached fields from `DailyState` and always compute daily totals dynamically from drink records using the 4am boundary logic (matching the iOS app).
+
+### Files to Modify
+
+1. **[firmware/include/drinks.h](firmware/include/drinks.h)** - Simplify DailyState struct
+2. **[firmware/src/drinks.cpp](firmware/src/drinks.cpp)** - Remove accumulation logic, always compute from records
+3. **[firmware/src/storage_drinks.cpp](firmware/src/storage_drinks.cpp)** - Update NVS functions for smaller struct
+
+### Changes
+
+#### 1. drinks.h - Simplify DailyState
+
+Remove redundant fields:
+```cpp
+// DailyState structure: Tracks drink detection state (8 bytes, down from 18)
+struct DailyState {
+    int32_t  last_recorded_adc;         // Baseline ADC value for drink detection
+    uint16_t last_displayed_total_ml;   // Last displayed total (for hysteresis)
+    uint16_t _reserved;                 // Padding for alignment
+};
+```
+
+Removed:
+- `last_reset_timestamp` - not needed, we use record timestamps
+- `last_drink_timestamp` - not needed for current logic
+- `daily_total_ml` - always computed from records
+- `drink_count_today` - always computed from records
+
+Add new function declaration:
+```cpp
+uint16_t drinksGetDailyTotal();  // Returns computed daily total
+uint16_t drinksGetDrinkCount();  // Returns computed drink count
+```
+
+#### 2. drinks.cpp - Major refactor
+
+- `drinksInit()`: Just load baseline ADC, call `drinksRecalculateTotal()` to initialize computed values
+- `drinksUpdate()`: Remove accumulation of `daily_total_ml`, rely on records
+- Remove `shouldResetDailyCounter()` and `performAtomicDailyReset()` - no longer needed
+- `drinksRecalculateTotal()`: Already correct, becomes the authoritative source
+- Add `drinksGetDailyTotal()` and `drinksGetDrinkCount()` that call recalculate or return cached computed values
+- Update `drinksCancelLast()` to just mark record deleted and recalculate
+- Update `drinksResetDaily()` to clear records for today
+
+#### 3. storage_drinks.cpp - Update for smaller struct
+
+The NVS load/save will automatically handle the smaller struct size. Old data will fail to load (size mismatch), which is fine - we'll initialize fresh and records are preserved.
+
+#### 4. main.cpp, display.cpp, ble_service.cpp - Use new API
+
+Replace `daily_state.daily_total_ml` with `drinksGetDailyTotal()` calls.
+
+### Data Migration
+
+- **Drink records**: Preserved (stored separately in circular buffer)
+- **Daily total**: Recomputed from records on first boot
+- **No data loss**: All historical drinks remain intact
+
+## Verification
+
+1. **Build firmware:** `cd firmware && ~/.platformio/penv/bin/platformio run`
+2. **Test scenario:**
+   - Record drinks before midnight
+   - After 4am the next day, power cycle the bottle
+   - Verify bottle shows 0ml (only today's drinks from 4am onwards)
+   - Verify iOS app and bottle totals match
+3. **Serial monitor:** Look for "Drinks: Recalculated total = Xml (Y drinks)" at boot

--- a/firmware/include/ble_service.h
+++ b/firmware/include/ble_service.h
@@ -148,7 +148,7 @@ void bleStopAdvertising();
  * @param time_valid Time set status
  * @param stable Weight stability status
  */
-void bleUpdateCurrentState(const DailyState& state, int32_t current_adc,
+void bleUpdateCurrentState(uint16_t daily_total_ml, int32_t current_adc,
                            const CalibrationData& cal, uint8_t battery_percent,
                            bool calibrated, bool time_valid, bool stable);
 

--- a/firmware/include/drinks.h
+++ b/firmware/include/drinks.h
@@ -18,14 +18,12 @@ struct DrinkRecord {
     uint8_t  type;              // Drink type: 0=gulp (<100ml), 1=pour (≥100ml)
 };
 
-// DailyState structure: Tracks current day's drinking state (18 bytes)
+// DailyState structure: Tracks drink detection state (8 bytes)
+// Note: daily_total_ml and drink_count are computed dynamically from records
 struct DailyState {
-    uint32_t last_reset_timestamp;      // Last 4am daily reset (Unix time)
-    uint32_t last_drink_timestamp;      // Most recent drink event (Unix time)
     int32_t  last_recorded_adc;         // Baseline ADC value for drink detection
-    uint16_t daily_total_ml;            // Today's cumulative water intake (ml)
-    uint16_t drink_count_today;         // Number of drink events today
     uint16_t last_displayed_total_ml;   // Last displayed total (for hysteresis)
+    uint16_t _reserved;                 // Padding for alignment
 };
 
 // Public API functions
@@ -62,23 +60,13 @@ uint32_t getCurrentUnixTime();
 void drinksGetState(DailyState& state);
 
 /**
- * Set daily intake to a specific value (for testing/manual adjustment)
- * Updates internal state and saves to NVS
- *
- * @param ml Daily intake value in milliliters (0-10000)
- * @return true if successful, false if value out of range
- */
-bool drinksSetDailyIntake(uint16_t ml);
-
-/**
- * Reset daily intake counter (for testing)
- * Clears daily total and drink count, keeps drink records
+ * Reset daily intake (marks today's drink records as deleted)
+ * Used for manual reset or testing
  */
 void drinksResetDaily();
 
 /**
- * Cancel the most recent drink record
- * Subtracts the last drink amount from daily total and decrements drink count
+ * Cancel the most recent drink record (marks it as deleted)
  * Used when bottle is emptied (shake to empty gesture)
  *
  * @return true if a drink was cancelled, false if no drinks to cancel
@@ -92,13 +80,25 @@ bool drinksCancelLast();
 void drinksClearAll();
 
 /**
- * Recalculate daily total from non-deleted drink records
- * Called after a record is soft-deleted via BLE command
- * Updates g_daily_state.daily_total_ml and saves to NVS
+ * Get current daily total (computed from drink records using 4am boundary)
+ * This is the authoritative source for daily intake
  *
- * @return The recalculated daily total in ml
+ * @return Today's cumulative water intake in ml
  */
-uint16_t drinksRecalculateTotal();
+uint16_t drinksGetDailyTotal();
+
+/**
+ * Get current drink count (computed from drink records using 4am boundary)
+ *
+ * @return Number of drink events today
+ */
+uint16_t drinksGetDrinkCount();
+
+/**
+ * Force recalculation of daily totals from drink records
+ * Call this after external changes to drink records (e.g., BLE delete)
+ */
+void drinksRecalculateTotals();
 
 /**
  * RTC memory persistence for deep sleep

--- a/firmware/src/ble_service.cpp
+++ b/firmware/src/ble_service.cpp
@@ -177,7 +177,7 @@ class CommandCallbacks : public NimBLECharacteristicCallbacks {
 
             bool found = storageMarkDeleted(recordId);
             if (found) {
-                drinksRecalculateTotal();
+                drinksRecalculateTotals();
                 BLE_DEBUG_F("DELETE_DRINK_RECORD: %lu deleted, total recalculated", recordId);
             } else {
                 BLE_DEBUG_F("DELETE_DRINK_RECORD: %lu not found (rolled off)", recordId);
@@ -684,14 +684,14 @@ void bleUpdateBatteryLevel(uint8_t percent) {
 }
 
 // Update Current State (Phase 3B - full implementation)
-void bleUpdateCurrentState(const DailyState& state, int32_t current_adc,
+void bleUpdateCurrentState(uint16_t daily_total_ml, int32_t current_adc,
                            const CalibrationData& cal, uint8_t battery_percent,
                            bool calibrated, bool time_valid, bool stable) {
     // Save previous state for change detection
     BLE_CurrentState previousState = currentState;
 
-    // Update timestamp
-    currentState.timestamp = state.last_drink_timestamp;
+    // Update timestamp (use current time)
+    currentState.timestamp = getCurrentUnixTime();
 
     // Calculate current weight from ADC if calibrated
     if (calibrated && cal.scale_factor != 0.0f) {
@@ -711,7 +711,7 @@ void bleUpdateCurrentState(const DailyState& state, int32_t current_adc,
     }
 
     // Update daily total
-    currentState.daily_total_ml = state.daily_total_ml;
+    currentState.daily_total_ml = daily_total_ml;
 
     // Update battery
     currentState.battery_percent = battery_percent;

--- a/firmware/src/drinks.cpp
+++ b/firmware/src/drinks.cpp
@@ -1,5 +1,8 @@
 // drinks.cpp - Daily water intake tracking implementation
 // Part of the Aquavate smart water bottle firmware
+//
+// Daily totals are computed dynamically from drink records using the 4am boundary,
+// matching the iOS app's calculation. This ensures consistency between devices.
 
 #include "drinks.h"
 #include "storage_drinks.h"
@@ -17,6 +20,10 @@ extern bool g_debug_drink_tracking; // Debug flag for drink tracking
 // Static state for drink detection
 static DailyState g_daily_state;
 static bool g_drinks_initialized = false;
+
+// Cached computed values (recalculated on init and after changes)
+static uint16_t g_cached_daily_total_ml = 0;
+static uint16_t g_cached_drink_count = 0;
 
 // RTC memory for drink detection baseline across deep sleep
 // Persists last stable ADC reading to prevent false drink detection on wake
@@ -45,62 +52,63 @@ static void saveTimestampOnEvent(const char* event_type) {
     }
 }
 
-// Helper: Check if daily counter should reset
-// Returns true on first drink after 4am boundary
-static bool shouldResetDailyCounter(uint32_t current_time) {
-    // First run - always reset
-    if (g_daily_state.last_reset_timestamp == 0) {
-        Serial.println("First run - initializing daily counter");
-        return true;
-    }
-
-    // Convert timestamps to struct tm for date comparison
-    time_t last_reset_t = g_daily_state.last_reset_timestamp;
+// Helper: Calculate today's 4am boundary timestamp
+static uint32_t getTodayResetTimestamp() {
+    uint32_t current_time = getCurrentUnixTime();
     time_t current_t = current_time;
-
-    struct tm last_reset_tm;
     struct tm current_tm;
-
-    gmtime_r(&last_reset_t, &last_reset_tm);
     gmtime_r(&current_t, &current_tm);
 
-    // Check if 20+ hours have passed (handles night-only drinking)
-    uint32_t hours_elapsed = (current_time - g_daily_state.last_reset_timestamp) / 3600;
-    if (hours_elapsed >= 20) {
-        Serial.println("20+ hours since last reset - triggering daily reset");
-        return true;
+    // Calculate timestamp for 4am today
+    struct tm reset_tm = current_tm;
+    reset_tm.tm_hour = DRINK_DAILY_RESET_HOUR;
+    reset_tm.tm_min = 0;
+    reset_tm.tm_sec = 0;
+    uint32_t today_reset_timestamp = (uint32_t)mktime(&reset_tm);
+
+    // If we're before 4am today, use yesterday's 4am as the reset boundary
+    if (current_tm.tm_hour < DRINK_DAILY_RESET_HOUR) {
+        today_reset_timestamp -= 24 * 3600;  // Subtract 24 hours
     }
 
-    // Check if we've crossed the 4am boundary
-    // Day changed AND current time >= 4am
-    if (last_reset_tm.tm_yday != current_tm.tm_yday ||
-        last_reset_tm.tm_year != current_tm.tm_year) {
-        // Different day - check if current time is past 4am
-        if (current_tm.tm_hour >= DRINK_DAILY_RESET_HOUR) {
-            Serial.println("Crossed 4am boundary - triggering daily reset");
-            return true;
+    return today_reset_timestamp;
+}
+
+// Helper: Recalculate daily totals from drink records
+// This is the authoritative calculation using the 4am boundary
+static void recalculateDailyTotals() {
+    uint32_t today_reset_timestamp = getTodayResetTimestamp();
+
+    // Load metadata
+    CircularBufferMetadata meta;
+    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
+        g_cached_daily_total_ml = 0;
+        g_cached_drink_count = 0;
+        Serial.println("Drinks: Recalculated total = 0ml (no records)");
+        return;
+    }
+
+    // Sum all today's non-deleted drink records
+    uint16_t total_ml = 0;
+    uint16_t drink_count = 0;
+
+    for (uint16_t i = 0; i < meta.record_count; i++) {
+        DrinkRecord record;
+        if (storageGetDrinkRecord(i, record)) {
+            // Check: from today (after 4am reset), not deleted, is a drink (positive amount)
+            if (record.timestamp >= today_reset_timestamp &&
+                (record.flags & 0x04) == 0 &&  // Not deleted
+                record.amount_ml > 0) {         // Drink, not refill
+                total_ml += (uint16_t)record.amount_ml;
+                drink_count++;
+            }
         }
     }
 
-    return false;
-}
+    g_cached_daily_total_ml = total_ml;
+    g_cached_drink_count = drink_count;
 
-// Helper: Perform atomic daily reset
-static void performAtomicDailyReset(uint32_t current_time) {
-    Serial.println("\n=== ATOMIC DAILY RESET ===");
-    Serial.printf("Previous total: %dml (%d drinks)\n",
-                 g_daily_state.daily_total_ml,
-                 g_daily_state.drink_count_today);
-
-    // Reset all daily counters atomically
-    g_daily_state.daily_total_ml = 0;
-    g_daily_state.drink_count_today = 0;
-    g_daily_state.last_displayed_total_ml = 0;
-    g_daily_state.last_reset_timestamp = current_time;
-    g_daily_state.last_recorded_adc = 0;  // Reset baseline ADC
-
-    storageSaveDailyState(g_daily_state);
-    Serial.println("Daily counter reset complete");
+    Serial.printf("Drinks: Recalculated total = %dml (%d drinks)\n", total_ml, drink_count);
 }
 
 // Initialize drink tracking system
@@ -111,18 +119,16 @@ void drinksInit() {
         return;
     }
 
-    // Load daily state from NVS
+    // Load daily state from NVS (baseline ADC and display threshold)
     if (!storageLoadDailyState(g_daily_state)) {
-        // First run - initialize state
+        // First run or struct size changed - initialize state
         Serial.println("Initializing new daily state");
         memset(&g_daily_state, 0, sizeof(DailyState));
-        g_daily_state.last_reset_timestamp = getCurrentUnixTime();
         storageSaveDailyState(g_daily_state);
     } else {
-        Serial.println("Loaded daily state from NVS:");
-        Serial.printf("  Daily total: %dml\n", g_daily_state.daily_total_ml);
-        Serial.printf("  Drink count: %d\n", g_daily_state.drink_count_today);
-        Serial.printf("  Last drink: %u\n", g_daily_state.last_drink_timestamp);
+        Serial.println("Loaded daily state from NVS");
+        Serial.printf("  Baseline ADC: %d\n", g_daily_state.last_recorded_adc);
+        Serial.printf("  Last displayed: %dml\n", g_daily_state.last_displayed_total_ml);
     }
 
     // IMPORTANT: Always reset baseline ADC on cold boot
@@ -130,7 +136,25 @@ void drinksInit() {
     // establish a fresh baseline to avoid false drink detection
     g_daily_state.last_recorded_adc = 0;
 
+    // Calculate daily totals from records (authoritative source)
+    recalculateDailyTotals();
+
     g_drinks_initialized = true;
+}
+
+// Get current daily total (computed from records)
+uint16_t drinksGetDailyTotal() {
+    return g_cached_daily_total_ml;
+}
+
+// Get current drink count (computed from records)
+uint16_t drinksGetDrinkCount() {
+    return g_cached_drink_count;
+}
+
+// Force recalculation of daily totals (public wrapper)
+void drinksRecalculateTotals() {
+    recalculateDailyTotals();
 }
 
 // Main drink detection and tracking update
@@ -141,13 +165,6 @@ bool drinksUpdate(int32_t current_adc, const CalibrationData& cal) {
     }
 
     uint32_t current_time = getCurrentUnixTime();
-
-    // Check for daily reset FIRST
-    if (shouldResetDailyCounter(current_time)) {
-        performAtomicDailyReset(current_time);
-        // Early return to establish fresh baseline on next call
-        return false;
-    }
 
     // Convert current ADC to ml using calibration
     float current_ml = calibrationGetWaterWeight(current_adc, cal);
@@ -195,7 +212,7 @@ bool drinksUpdate(int32_t current_adc, const CalibrationData& cal) {
 
         Serial.printf("\n=== DRINK DETECTED: %.1fml (%s) ===\n", delta_ml, type_str);
 
-        // Create new drink record (no aggregation)
+        // Create new drink record
         DrinkRecord record;
         record.timestamp = current_time;
         record.amount_ml = (int16_t)delta_ml;
@@ -205,29 +222,26 @@ bool drinksUpdate(int32_t current_adc, const CalibrationData& cal) {
 
         storageSaveDrinkRecord(record);
 
-        // Update daily total
-        g_daily_state.daily_total_ml += (uint16_t)delta_ml;
-        g_daily_state.drink_count_today++;
-        g_daily_state.last_drink_timestamp = current_time;
+        // Update baseline
         g_daily_state.last_recorded_adc = current_adc;
-
         storageSaveDailyState(g_daily_state);
+
+        // Recalculate totals from records
+        recalculateDailyTotals();
 
         // Save timestamp to NVS on drink event (for time persistence)
         saveTimestampOnEvent("drink");
 
         Serial.printf("Daily total: %dml (%d drinks)\n",
-                     g_daily_state.daily_total_ml,
-                     g_daily_state.drink_count_today);
+                     g_cached_daily_total_ml, g_cached_drink_count);
 
         // Check if display should update (≥50ml change)
-        uint16_t display_delta = abs((int)g_daily_state.daily_total_ml -
+        uint16_t display_delta = abs((int)g_cached_daily_total_ml -
                                      (int)g_daily_state.last_displayed_total_ml);
         if (display_delta >= DRINK_DISPLAY_UPDATE_THRESHOLD_ML) {
             Serial.println("Display update threshold reached - should refresh");
-            g_daily_state.last_displayed_total_ml = g_daily_state.daily_total_ml;
+            g_daily_state.last_displayed_total_ml = g_cached_daily_total_ml;
             storageSaveDailyState(g_daily_state);
-            // TODO: Trigger display refresh
         }
         return true;  // Drink was recorded
     }
@@ -257,134 +271,80 @@ void drinksGetState(DailyState& state) {
     state = g_daily_state;
 }
 
-// Debug function: Set daily intake to a specific value
-bool drinksSetDailyIntake(uint16_t ml) {
-    if (ml > 10000) {
-        return false;  // Value out of range
-    }
-
-    if (!g_drinks_initialized) {
-        // Initialize if not already done
-        drinksInit();
-    }
-
-    // Update daily total
-    uint16_t previous_total = g_daily_state.daily_total_ml;
-    g_daily_state.daily_total_ml = ml;
-
-    // Save to NVS
-    if (!storageSaveDailyState(g_daily_state)) {
-        return false;
-    }
-
-    Serial.printf("Daily intake set: %dml (was %dml)\n", ml, previous_total);
-    return true;
-}
-
-// Debug function: Reset daily intake (for testing)
+// Reset daily intake (marks today's records as deleted)
 void drinksResetDaily() {
     Serial.println("=== MANUAL DAILY RESET ===");
-    performAtomicDailyReset(getCurrentUnixTime());
-    Serial.println("Daily intake reset to 0ml");
-}
 
-// Recalculate daily total from non-deleted drink records
-// Called after a record is soft-deleted via BLE command
-uint16_t drinksRecalculateTotal() {
-    uint32_t current_time = getCurrentUnixTime();
+    uint32_t today_reset_timestamp = getTodayResetTimestamp();
 
-    // Calculate today's 4am boundary
-    time_t current_t = current_time;
-    struct tm current_tm;
-    gmtime_r(&current_t, &current_tm);
-
-    // Calculate timestamp for 4am today (or yesterday if before 4am)
-    struct tm reset_tm = current_tm;
-    reset_tm.tm_hour = DRINK_DAILY_RESET_HOUR;
-    reset_tm.tm_min = 0;
-    reset_tm.tm_sec = 0;
-    uint32_t today_reset_timestamp = (uint32_t)mktime(&reset_tm);
-
-    // If we're before 4am today, use yesterday's 4am as the reset boundary
-    if (current_tm.tm_hour < DRINK_DAILY_RESET_HOUR) {
-        today_reset_timestamp -= 24 * 3600;  // Subtract 24 hours
-    }
-
-    // Load metadata
+    // Mark all today's drink records as deleted
     CircularBufferMetadata meta;
-    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
-        g_daily_state.daily_total_ml = 0;
-        g_daily_state.drink_count_today = 0;
-        storageSaveDailyState(g_daily_state);
-        Serial.println("Drinks: Recalculated total = 0ml (no records)");
-        return 0;
-    }
-
-    // Sum all today's non-deleted drink records
-    uint16_t total_ml = 0;
-    uint16_t drink_count = 0;
-
-    for (uint16_t i = 0; i < meta.record_count; i++) {
-        DrinkRecord record;
-        if (storageGetDrinkRecord(i, record)) {
-            // Check: from today (after 4am reset), not deleted, is a drink (positive amount)
-            if (record.timestamp >= today_reset_timestamp &&
-                (record.flags & 0x04) == 0 &&  // Not deleted
-                record.amount_ml > 0) {         // Drink, not refill
-                total_ml += (uint16_t)record.amount_ml;
-                drink_count++;
+    if (storageLoadBufferMetadata(meta) && meta.record_count > 0) {
+        for (uint16_t i = 0; i < meta.record_count; i++) {
+            DrinkRecord record;
+            if (storageGetDrinkRecord(i, record)) {
+                if (record.timestamp >= today_reset_timestamp &&
+                    (record.flags & 0x04) == 0 &&  // Not already deleted
+                    record.amount_ml > 0) {         // Drink, not refill
+                    // Mark as deleted
+                    storageMarkDeleted(record.record_id);
+                }
             }
         }
     }
 
-    // Update daily state
-    g_daily_state.daily_total_ml = total_ml;
-    g_daily_state.drink_count_today = drink_count;
+    // Recalculate (should be 0 now)
+    recalculateDailyTotals();
+
+    // Reset display threshold
+    g_daily_state.last_displayed_total_ml = 0;
     storageSaveDailyState(g_daily_state);
 
-    Serial.printf("Drinks: Recalculated total = %dml (%d drinks)\n", total_ml, drink_count);
-    return total_ml;
+    Serial.println("Daily intake reset to 0ml");
 }
 
-// Cancel the most recent drink record (bottle emptied gesture)
+// Cancel the most recent drink record (marks it as deleted)
 bool drinksCancelLast() {
-    // Check if any drinks today
-    if (g_daily_state.drink_count_today == 0) {
+    uint32_t today_reset_timestamp = getTodayResetTimestamp();
+
+    // Find the most recent non-deleted drink from today
+    CircularBufferMetadata meta;
+    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
+        Serial.println("Drinks: No records to cancel");
+        return false;
+    }
+
+    // Search backwards for the most recent drink
+    DrinkRecord last_drink;
+    bool found = false;
+
+    // Iterate from newest to oldest
+    for (int i = meta.record_count - 1; i >= 0; i--) {
+        DrinkRecord record;
+        if (storageGetDrinkRecord(i, record)) {
+            if (record.timestamp >= today_reset_timestamp &&
+                (record.flags & 0x04) == 0 &&  // Not deleted
+                record.amount_ml > 0) {         // Drink, not refill
+                last_drink = record;
+                found = true;
+                break;
+            }
+        }
+    }
+
+    if (!found) {
         Serial.println("Drinks: No drinks to cancel");
         return false;
     }
 
-    // Load last drink record
-    DrinkRecord last_drink;
-    if (!storageLoadLastDrinkRecord(last_drink)) {
-        Serial.println("Drinks: Failed to load last drink record");
-        return false;
-    }
+    // Mark as deleted
+    storageMarkDeleted(last_drink.record_id);
 
-    // Verify it's a drink (positive amount) not a refill
-    if (last_drink.amount_ml <= 0) {
-        Serial.println("Drinks: Last record is a refill, not cancelling");
-        return false;
-    }
+    // Recalculate totals
+    recalculateDailyTotals();
 
-    // Subtract from daily total
-    uint16_t cancel_amount = (uint16_t)last_drink.amount_ml;
-    if (g_daily_state.daily_total_ml >= cancel_amount) {
-        g_daily_state.daily_total_ml -= cancel_amount;
-    } else {
-        g_daily_state.daily_total_ml = 0;
-    }
-
-    // Decrement drink count
-    if (g_daily_state.drink_count_today > 0) {
-        g_daily_state.drink_count_today--;
-    }
-
-    // Save updated state
-    storageSaveDailyState(g_daily_state);
-
-    Serial.printf("Drinks: Cancelled last drink of %dml. New total: %dml (%d drinks)\n",
-                  cancel_amount, g_daily_state.daily_total_ml, g_daily_state.drink_count_today);
+    Serial.printf("Drinks: Cancelled drink of %dml. New total: %dml (%d drinks)\n",
+                  last_drink.amount_ml, g_cached_daily_total_ml, g_cached_drink_count);
 
     return true;
 }
@@ -395,7 +355,6 @@ void drinksClearAll() {
 
     // Reset daily state
     memset(&g_daily_state, 0, sizeof(DailyState));
-    g_daily_state.last_reset_timestamp = getCurrentUnixTime();
     storageSaveDailyState(g_daily_state);
 
     // Reset circular buffer metadata
@@ -406,6 +365,10 @@ void drinksClearAll() {
     meta.next_record_id = 1;  // Start IDs at 1 (0 = invalid/unassigned)
     meta._reserved = 0;
     storageSaveBufferMetadata(meta);
+
+    // Reset cached values
+    g_cached_daily_total_ml = 0;
+    g_cached_drink_count = 0;
 
     Serial.println("All drink records cleared");
 }


### PR DESCRIPTION
## Summary
- Daily totals now computed dynamically from drink records using the 4am boundary
- Matches iOS app calculation logic for consistency between devices
- Removed redundant cached fields from `DailyState` struct (18 bytes → 8 bytes)
- Deprecated `SET_DAILY_INTAKE` serial command (totals computed from records)

See [Plan 031](Plans/031-daily-reset-from-records.md) for full implementation details.

Fixes #17

## Test plan
- [x] Firmware builds successfully
- [ ] Power cycle bottle after 4am - verify daily total shows only drinks from today
- [x] Verify iOS app and bottle totals match
- [ ] Test `RESET DAILY INTAKE` serial command marks today's records as deleted
- [x] Check serial monitor shows "Drinks: Recalculated total = Xml (Y drinks)" at boot

🤖 Generated with [Claude Code](https://claude.ai/code)