### PR TITLE
Fix hydration graphic not updating on drink deletion

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -13,6 +13,11 @@
 
 ## Recently Completed
 
+- ✅ Fix Hydration Graphic Update on Deletion (Issue #20) - [Plan 032](Plans/032-hydration-graphic-update-fix.md)
+  - iOS: Added `@MainActor` to Task in BLE deletion completion handler (HomeView.swift)
+  - Firmware: Synced daily goal between display and BLE config (now uses DRINK_DAILY_GOAL_ML=2500)
+  - Added `displaySetDailyGoal()` function for runtime configuration
+  - Fixed bottleConfig defaults to prevent divide-by-zero
 - ✅ Fix Daily Intake Reset at 4am (Issue #17) - [Plan 031](Plans/031-daily-reset-from-records.md)
   - Removed redundant cached fields from DailyState struct
   - Daily totals now computed dynamically from drink records using 4am boundary
@@ -42,7 +47,7 @@
 
 ## Branch Status
 
-- `master` - Stable baseline (HealthKit integration merged)
+- `master` - Stable baseline
 
 ---
 

--- a/Plans/032-hydration-graphic-update-fix.md
+++ b/Plans/032-hydration-graphic-update-fix.md
@@ -1,0 +1,65 @@
+# Plan: Fix Hydration Graphic Not Updating on Drink Deletion (Issue #20)
+
+## Problem Summary
+
+When deleting a drink record from the iOS app, the list updates correctly but the `HumanFigureProgressView` (the "filled man" graphic) does not reflect the new daily total.
+
+## Root Cause Analysis
+
+The issue is in [HomeView.swift:98-110](ios/Aquavate/Aquavate/Views/HomeView.swift#L98-L110). When a drink is deleted:
+
+```swift
+bleManager.deleteDrinkRecord(firmwareRecordId: UInt32(firmwareId)) { success in
+    if success {
+        Task {  // ← Problem: No @MainActor annotation
+            // HealthKit delete...
+            PersistenceController.shared.deleteDrinkRecord(id: id)
+        }
+    }
+    continuation.resume()
+}
+```
+
+**The bug**: The BLE completion handler is called from a CoreBluetooth background thread. The inner `Task { ... }` without `@MainActor` runs the CoreData deletion on an unspecified executor. Since CoreData's `viewContext` must be accessed from the main thread:
+
+1. The deletion may execute from a background thread
+2. CoreData change notifications don't propagate correctly to the `@FetchRequest`
+3. The `HumanFigureProgressView` receives stale `displayDailyTotal` value
+
+**Why the list updates**: The list uses `ForEach(todaysDrinksCD)` which iterates the `@FetchRequest` directly. SwiftUI's list diffing may detect the removal through a different mechanism than the view's body re-evaluation.
+
+## Solution
+
+Change the inner `Task` to `Task { @MainActor in ... }` to ensure the CoreData deletion happens on the main thread.
+
+## Implementation
+
+### File: [ios/Aquavate/Aquavate/Views/HomeView.swift](ios/Aquavate/Aquavate/Views/HomeView.swift)
+
+**Change at line 98**: Add `@MainActor` to the Task:
+
+```swift
+// Before:
+Task {
+    if let hkUUID = healthKitUUID,
+
+// After:
+Task { @MainActor in
+    if let hkUUID = healthKitUUID,
+```
+
+This single change ensures:
+1. CoreData deletion runs on the main thread
+2. `@FetchRequest` notifications propagate correctly
+3. `displayDailyTotal` is recalculated when the view body re-evaluates
+4. `HumanFigureProgressView` receives the updated value
+
+## Verification
+
+1. Build the iOS app in Xcode
+2. Connect to the bottle (or use preview/simulator with mock data)
+3. Add multiple drink records
+4. Observe the hydration graphic fill level
+5. Delete a drink record by swiping
+6. **Verify**: Both the list AND the hydration graphic update to reflect the deletion
+7. Check the daily total text matches the graphic fill level

--- a/firmware/include/ble_service.h
+++ b/firmware/include/ble_service.h
@@ -52,7 +52,7 @@ struct __attribute__((packed)) BLE_BottleConfig {
     float    scale_factor;        // ADC counts per gram
     int32_t  tare_weight_grams;   // Empty bottle weight
     uint16_t bottle_capacity_ml;  // Max capacity (default 830ml)
-    uint16_t daily_goal_ml;       // User's daily target (default 2000ml)
+    uint16_t daily_goal_ml;       // User's daily target (default DRINK_DAILY_GOAL_ML)
 };
 
 // Sync Control Characteristic (8 bytes)
@@ -174,6 +174,12 @@ bool bleCheckResetDailyRequested();
 bool bleCheckClearHistoryRequested();
 bool bleCheckSetDailyTotalRequested(uint16_t& value);
 bool bleCheckForceDisplayRefresh();
+
+/**
+ * Get daily hydration goal from bottle config
+ * @return Daily goal in ml (default 2500)
+ */
+uint16_t bleGetDailyGoalMl();
 
 #endif // ENABLE_BLE
 

--- a/firmware/include/display.h
+++ b/firmware/include/display.h
@@ -22,6 +22,7 @@ struct DisplayState {
 
 // Public API
 void displayInit(ThinkInk_213_Mono_GDEY0213B74& display_ref);
+void displaySetDailyGoal(uint16_t goal_ml);
 bool displayNeedsUpdate(float current_water_ml,
                        uint16_t current_daily_ml,
                        bool time_interval_elapsed,

--- a/firmware/src/ble_service.cpp
+++ b/firmware/src/ble_service.cpp
@@ -44,8 +44,13 @@ static bool isAdvertising = false;
 static BLE_CurrentState currentState = {0};
 static uint8_t lastBatteryPercent = 0;
 
-// Bottle config cache
-static BLE_BottleConfig bottleConfig = {0};
+// Bottle config cache (defaults used if no calibration data)
+static BLE_BottleConfig bottleConfig = {
+    .scale_factor = 1.0f,
+    .tare_weight_grams = 0,
+    .bottle_capacity_ml = 830,
+    .daily_goal_ml = DRINK_DAILY_GOAL_ML
+};
 
 // Sync Control state
 static BLE_SyncControl syncControl = {0};
@@ -387,7 +392,7 @@ void bleLoadBottleConfig() {
         bottleConfig.scale_factor = cal.scale_factor;
         bottleConfig.tare_weight_grams = (int32_t)(cal.empty_bottle_adc / cal.scale_factor);
         bottleConfig.bottle_capacity_ml = 830; // Default capacity (could be configurable later)
-        bottleConfig.daily_goal_ml = 2000;     // Default goal (could be configurable later)
+        bottleConfig.daily_goal_ml = DRINK_DAILY_GOAL_ML;
 
         // Update characteristic value
         if (pBottleConfigChar) {
@@ -808,6 +813,10 @@ bool bleCheckForceDisplayRefresh() {
         return true;
     }
     return false;
+}
+
+uint16_t bleGetDailyGoalMl() {
+    return bottleConfig.daily_goal_ml;
 }
 
 #endif // ENABLE_BLE

--- a/firmware/src/display.cpp
+++ b/firmware/src/display.cpp
@@ -30,6 +30,9 @@ extern int getBatteryPercent(float voltage);
 static DisplayState g_display_state;
 static ThinkInk_213_Mono_GDEY0213B74* g_display_ptr = nullptr;
 
+// Daily goal for hydration graphic (synced from BLE config, default matches DRINK_DAILY_GOAL_ML)
+static uint16_t g_daily_goal_ml = DRINK_DAILY_GOAL_ML;
+
 // RTC memory for display state persistence across deep sleep
 // RTC_DATA_ATTR keeps data in RTC slow memory (survives deep sleep, lost on power cycle)
 #define RTC_MAGIC_DISPLAY 0x41515541  // "AQUA" in hex
@@ -507,6 +510,11 @@ void displayInit(ThinkInk_213_Mono_GDEY0213B74& display_ref) {
     Serial.println("Display: Initialized state tracking");
 }
 
+void displaySetDailyGoal(uint16_t goal_ml) {
+    g_daily_goal_ml = goal_ml;
+    Serial.printf("Display: Daily goal set to %dml\n", goal_ml);
+}
+
 bool displayNeedsUpdate(float current_water_ml,
                        uint16_t current_daily_ml,
                        bool time_interval_elapsed,
@@ -731,9 +739,9 @@ void drawMainScreen() {
     float daily_fill = 0.0f;
     bool goal_reached = false;
     if (g_time_valid) {
-        daily_fill = (float)g_display_state.daily_total_ml / (float)DRINK_DAILY_GOAL_ML;
+        daily_fill = (float)g_display_state.daily_total_ml / (float)g_daily_goal_ml;
         if (daily_fill > 1.0f) daily_fill = 1.0f;
-        goal_reached = (g_display_state.daily_total_ml >= DRINK_DAILY_GOAL_ML);
+        goal_reached = (g_display_state.daily_total_ml >= g_daily_goal_ml);
     }
 
     // Use runtime display mode instead of compile-time constant (shifted down 3px)

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -918,6 +918,9 @@ void setup() {
     if (bleInit()) {
         Serial.println("BLE service initialized!");
 
+        // Sync daily goal from BLE config to display
+        displaySetDailyGoal(bleGetDailyGoalMl());
+
         // Start advertising on motion wake (not timer wake)
         if (wakeup_reason == ESP_SLEEP_WAKEUP_EXT0) {
             Serial.println("Motion wake detected - starting BLE advertising");

--- a/ios/Aquavate/Aquavate/Views/HomeView.swift
+++ b/ios/Aquavate/Aquavate/Views/HomeView.swift
@@ -95,7 +95,7 @@ struct HomeView: View {
                         bleManager.deleteDrinkRecord(firmwareRecordId: UInt32(firmwareId)) { success in
                             if success {
                                 // Delete from HealthKit first (if synced)
-                                Task {
+                                Task { @MainActor in
                                     if let hkUUID = healthKitUUID,
                                        self.healthKitManager.isEnabled && self.healthKitManager.isAuthorized {
                                         do {


### PR DESCRIPTION
## Summary

Fixes #20 - When deleting a drink record, the list updated but the hydration graphic (HumanFigureProgressView) did not reflect the new total.

## Changes

- **iOS App**: Added `@MainActor` to nested Task in BLE deletion completion handler to ensure CoreData changes propagate correctly to SwiftUI's `@FetchRequest` observers
- **Firmware**: Synced daily goal between e-paper display and BLE config characteristic (both now use `DRINK_DAILY_GOAL_ML = 2500ml`)
- Added `displaySetDailyGoal()` function for runtime goal configuration
- Initialized `bottleConfig` with sensible defaults to prevent divide-by-zero

## Test Plan

- [x] Firmware builds successfully
- [x] Delete drink record from iOS app while connected to bottle
- [x] Verify both drink list AND hydration graphic update after deletion
- [x] Verify bottle e-paper display and iOS app show same fill level for daily goal

## Details

See [Plans/032-hydration-graphic-update-fix.md](Plans/032-hydration-graphic-update-fix.md) for full implementation details.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)