### PR TITLE
Settings page cleanup (Issue #22)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,12 +7,17 @@
 
 ## Current Status
 
-**IDLE** - No active development task
+**IDLE** - No active tasks
 
 ---
 
 ## Recently Completed
 
+- ✅ Settings Page Cleanup (Issue #22) - [Plan 033](Plans/033-settings-page-cleanup.md)
+  - Replaced hardcoded `Bottle.sample` with live BLEManager properties
+  - Removed unused `useOunces` preference
+  - Removed version string from About section
+  - Device name now persists after disconnect (shows last connected device)
 - ✅ Fix Hydration Graphic Update on Deletion (Issue #20) - [Plan 032](Plans/032-hydration-graphic-update-fix.md)
   - iOS: Added `@MainActor` to Task in BLE deletion completion handler (HomeView.swift)
   - Firmware: Synced daily goal between display and BLE config (now uses DRINK_DAILY_GOAL_ML=2500)

--- a/Plans/033-settings-page-cleanup.md
+++ b/Plans/033-settings-page-cleanup.md
@@ -1,0 +1,134 @@
+# Plan: GitHub Issue #22 - Settings Page Cleanup
+
+**Status:** ✅ Complete (2026-01-22)
+
+## Summary
+
+Four changes:
+1. Replace hardcoded `Bottle.sample` with live BLE data from `BLEManager`
+2. Remove unused `useOunces` preference
+3. Remove version string from About section
+4. Keep device name after disconnect (so it shows last connected device)
+
+## Changes
+
+### 1. Replace Bottle.sample with BLEManager Properties
+
+**Remove line 13:**
+```swift
+let bottle = Bottle.sample
+```
+
+**Update lines 170-191** - Replace:
+```swift
+Section("Bottle Configuration") {
+    HStack {
+        Text("Name")
+        Spacer()
+        Text(bottle.name)
+            .foregroundStyle(.secondary)
+    }
+
+    HStack {
+        Text("Capacity")
+        Spacer()
+        Text("\(bottle.capacityMl)ml")
+            .foregroundStyle(.secondary)
+    }
+
+    HStack {
+        Text("Daily Goal")
+        Spacer()
+        Text("\(bottle.dailyGoalMl)ml")
+            .foregroundStyle(.secondary)
+    }
+}
+```
+
+With:
+```swift
+Section("Bottle Configuration") {
+    HStack {
+        Text("Device")
+        Spacer()
+        Text(bleManager.connectedDeviceName ?? "Not connected")
+            .foregroundStyle(.secondary)
+    }
+
+    HStack {
+        Text("Capacity")
+        Spacer()
+        Text("\(bleManager.bottleCapacityMl)ml")
+            .foregroundStyle(.secondary)
+    }
+
+    HStack {
+        Text("Daily Goal")
+        Spacer()
+        Text("\(bleManager.dailyGoalMl)ml")
+            .foregroundStyle(.secondary)
+    }
+}
+```
+
+BLEManager already exposes these `@Published` properties - no changes needed there.
+
+### 2. Remove useOunces Preference
+
+**Remove line 14:**
+```swift
+@State private var useOunces = false
+```
+
+**Remove lines 375-381** (the Toggle in Preferences section):
+```swift
+Toggle(isOn: $useOunces) {
+    HStack {
+        Image(systemName: "ruler")
+            .foregroundStyle(.orange)
+        Text("Use Ounces (oz)")
+    }
+}
+```
+
+### 3. Remove Version String
+
+**Remove lines 393-400** (the Version row in About section):
+```swift
+HStack {
+    Text("Version")
+    Spacer()
+    Text("1.0.0 (Pull-to-Refresh)")
+        .foregroundStyle(.secondary)
+        .font(.caption)
+}
+```
+
+### 4. Keep Device Name After Disconnect
+
+In BLEManager.swift, **remove** the lines that clear `connectedDeviceName` on disconnect:
+
+- Line 350: `connectedDeviceName = nil` (connection timeout)
+- Line 456: `connectedDeviceName = nil` (connection failed)
+- Line 471: `connectedDeviceName = nil` (disconnected)
+
+This way, the last connected device name persists in memory. The device name (e.g., "Aquavate-A3F2") is based on MAC address and never changes.
+
+**Update SettingsView** to show "Not connected" only when `connectedDeviceName` is truly nil (never connected):
+```swift
+Text(bleManager.connectedDeviceName ?? "Not connected")
+```
+
+## Files to Modify
+
+- [SettingsView.swift](ios/Aquavate/Aquavate/Views/SettingsView.swift) - Changes 1, 2, 3
+- [BLEManager.swift](ios/Aquavate/Aquavate/Services/BLEManager.swift) - Change 4 (keep device name)
+
+## Verification
+
+1. Build iOS app: `xcodebuild -project ios/Aquavate/Aquavate.xcodeproj -scheme Aquavate build`
+2. Run in simulator - open Settings tab
+3. Verify:
+   - **Bottle Configuration**: Shows "Device" with device name (or "Not connected"), Capacity and Daily Goal from BLE
+   - **Preferences**: Only shows Notifications toggle (no Use Ounces)
+   - **About**: Only shows GitHub Repository link (no Version row)

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -1,10 +1,11 @@
 # Aquavate iOS App - UX Product Requirements Document
 
-**Version:** 1.5
-**Date:** 2026-01-21
-**Status:** Approved and Tested (HealthKit Integration)
+**Version:** 1.6
+**Date:** 2026-01-22
+**Status:** Approved and Tested (Settings Cleanup)
 
 **Changelog:**
+- **v1.6 (2026-01-22):** Settings page cleanup - replaced static "Name" with live "Device" showing connected device name, removed unused "Use Ounces" toggle, removed Version row from About section.
 - **v1.5 (2026-01-21):** Added Apple HealthKit integration (Section 2.7). Drinks sync to Health app as water intake samples. Added day boundary documentation (4am vs midnight).
 - **v1.4 (2026-01-21):** Bidirectional drink record sync. Swipe-to-delete now requires bottle connection and uses pessimistic delete with firmware confirmation. HomeView shows ALL today's drinks (not just recent 5).
 - **v1.3 (2026-01-20):** Added swipe-to-delete for drink records (Section 4 Gestures). Updated Reset Daily to also clear today's CoreData records.
@@ -442,7 +443,7 @@ Sarah's Bluetooth is accidentally turned off. When she opens the app, she sees a
 │                                 │
 │  BOTTLE CONFIGURATION           │  ← Section header
 │  ┌─────────────────────────────┐│
-│  │ Name           My Bottle    ││
+│  │ Device      Aquavate-A3F2   ││  ← Shows connected/last device name
 │  ├─────────────────────────────┤│
 │  │ Capacity           750ml    ││
 │  ├─────────────────────────────┤│
@@ -480,15 +481,11 @@ Sarah's Bluetooth is accidentally turned off. When she opens the app, she sees a
 │                                 │
 │  PREFERENCES                    │
 │  ┌─────────────────────────────┐│
-│  │ 📏 Use Ounces        [OFF]  ││  ← Toggle
-│  ├─────────────────────────────┤│
-│  │ 🔔 Notifications     [ON]   ││
+│  │ 🔔 Notifications     [ON]   ││  ← Toggle
 │  └─────────────────────────────┘│
 │                                 │
 │  ABOUT                          │
 │  ┌─────────────────────────────┐│
-│  │ Version      1.0.0 (Build 1)││
-│  ├─────────────────────────────┤│
 │  │ 🔗 GitHub Repository    →   ││
 │  └─────────────────────────────┘│
 │                                 │

--- a/ios/Aquavate/Aquavate/Services/BLEManager.swift
+++ b/ios/Aquavate/Aquavate/Services/BLEManager.swift
@@ -347,7 +347,6 @@ class BLEManager: NSObject, ObservableObject {
             connectionState = .disconnected
             errorMessage = "Connection timeout"
             connectedPeripheral = nil
-            connectedDeviceName = nil
         }
     }
 
@@ -453,7 +452,6 @@ extension BLEManager: CBCentralManagerDelegate {
             connectionState = .disconnected
             errorMessage = "Failed to connect: \(error?.localizedDescription ?? "Unknown error")"
             connectedPeripheral = nil
-            connectedDeviceName = nil
         }
     }
 
@@ -468,7 +466,6 @@ extension BLEManager: CBCentralManagerDelegate {
 
             connectionState = .disconnected
             connectedPeripheral = nil
-            connectedDeviceName = nil
             characteristics.removeAll()
         }
     }

--- a/ios/Aquavate/Aquavate/Views/SettingsView.swift
+++ b/ios/Aquavate/Aquavate/Views/SettingsView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject var bleManager: BLEManager
     @EnvironmentObject var healthKitManager: HealthKitManager
-    let bottle = Bottle.sample
-    @State private var useOunces = false
     @State private var notificationsEnabled = true
 
     private var connectionStatusColor: Color {
@@ -169,23 +167,23 @@ struct SettingsView: View {
                 // Bottle Configuration
                 Section("Bottle Configuration") {
                     HStack {
-                        Text("Name")
+                        Text("Device")
                         Spacer()
-                        Text(bottle.name)
+                        Text(bleManager.connectedDeviceName ?? "Not connected")
                             .foregroundStyle(.secondary)
                     }
 
                     HStack {
                         Text("Capacity")
                         Spacer()
-                        Text("\(bottle.capacityMl)ml")
+                        Text("\(bleManager.bottleCapacityMl)ml")
                             .foregroundStyle(.secondary)
                     }
 
                     HStack {
                         Text("Daily Goal")
                         Spacer()
-                        Text("\(bottle.dailyGoalMl)ml")
+                        Text("\(bleManager.dailyGoalMl)ml")
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -372,14 +370,6 @@ struct SettingsView: View {
 
                 // Preferences
                 Section("Preferences") {
-                    Toggle(isOn: $useOunces) {
-                        HStack {
-                            Image(systemName: "ruler")
-                                .foregroundStyle(.orange)
-                            Text("Use Ounces (oz)")
-                        }
-                    }
-
                     Toggle(isOn: $notificationsEnabled) {
                         HStack {
                             Image(systemName: "bell.fill")
@@ -391,14 +381,6 @@ struct SettingsView: View {
 
                 // About
                 Section("About") {
-                    HStack {
-                        Text("Version")
-                        Spacer()
-                        Text("1.0.0 (Pull-to-Refresh)")
-                            .foregroundStyle(.secondary)
-                            .font(.caption)
-                    }
-
                     Link(destination: URL(string: "https://github.com/bowerhaus/Aquavate")!) {
                         HStack {
                             Image(systemName: "link")


### PR DESCRIPTION
## Summary

- Replace hardcoded `Bottle.sample` with live `BLEManager` properties in Settings
- Remove unused `useOunces` preference toggle from Preferences section
- Remove version string from About section
- Keep device name after disconnect (shows last connected device name)

See [Plans/033-settings-page-cleanup.md](Plans/033-settings-page-cleanup.md) for full implementation details.

## Test Plan

- [x] iOS build succeeds (`xcodebuild build`)
- [x] Manual testing: Verify Settings shows Device name from BLEManager
- [x] Manual testing: Verify Preferences section only shows Notifications toggle
- [x] Manual testing: Verify About section only shows GitHub Repository link
- [x] Manual testing: Verify device name persists after disconnect

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)