### PR TITLE
Add dual licensing (PolyForm NC + CC BY-NC-SA 4.0)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,55 @@
+# Aquavate License
+
+Copyright (c) 2024-2025 Andy Bower
+
+Aquavate is dual-licensed under two separate licenses depending on the component type.
+
+## Software (Firmware & iOS App)
+
+All software components are licensed under the **PolyForm Noncommercial License 1.0.0**.
+
+This includes:
+- `firmware/` - ESP32 firmware source code
+- `ios/` - iOS application source code
+
+See [licenses/POLYFORM-NONCOMMERCIAL-1.0.0.txt](licenses/POLYFORM-NONCOMMERCIAL-1.0.0.txt) for the full license text.
+
+## Hardware Designs & Documentation
+
+All hardware designs and documentation are licensed under **Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)**.
+
+This includes:
+- `Plans/` - Design documents, schematics, and specifications
+- `docs/` - Project documentation
+- Hardware CAD files and PCB designs
+
+See [licenses/CC-BY-NC-SA-4.0.txt](licenses/CC-BY-NC-SA-4.0.txt) for the full license text.
+
+## What This Means
+
+### You CAN:
+- Use Aquavate for personal, non-commercial projects
+- Modify the code and designs for your own use
+- Share your modifications (under the same license terms)
+- Use it for educational purposes
+- Use it for research and experimentation
+
+### You CANNOT:
+- Sell products based on Aquavate without permission
+- Use Aquavate in commercial products or services without permission
+- Remove attribution or license notices
+
+### You MUST:
+- Include attribution to the original project
+- Share any modifications under the same license terms
+- Include a copy of the relevant license with any distribution
+
+## Commercial Licensing
+
+If you wish to use Aquavate for commercial purposes, please open an issue on GitHub to discuss licensing arrangements:
+
+https://github.com/bowerhaus/Aquavate/issues
+
+## Third-Party Components
+
+This project includes third-party libraries with their own licenses. See the respective library directories for their license terms.

--- a/licenses/CC-BY-NC-SA-4.0.txt
+++ b/licenses/CC-BY-NC-SA-4.0.txt
@@ -1,0 +1,34 @@
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+
+SPDX-License-Identifier: CC-BY-NC-SA-4.0
+
+This work is licensed under the Creative Commons
+Attribution-NonCommercial-ShareAlike 4.0 International License.
+
+You are free to:
+
+  - Share: copy and redistribute the material in any medium or format
+  - Adapt: remix, transform, and build upon the material
+
+Under the following terms:
+
+  - Attribution: You must give appropriate credit, provide a link to
+    the license, and indicate if changes were made. You may do so in
+    any reasonable manner, but not in any way that suggests the
+    licensor endorses you or your use.
+
+  - NonCommercial: You may not use the material for commercial purposes.
+
+  - ShareAlike: If you remix, transform, or build upon the material,
+    you must distribute your contributions under the same license as
+    the original.
+
+  - No additional restrictions: You may not apply legal terms or
+    technological measures that legally restrict others from doing
+    anything the license permits.
+
+The full legal text of this license is available at:
+https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+
+To view a human-readable summary, visit:
+https://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/licenses/POLYFORM-NONCOMMERCIAL-1.0.0.txt
+++ b/licenses/POLYFORM-NONCOMMERCIAL-1.0.0.txt
@@ -1,0 +1,129 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software
+to do everything you might do with the software that would
+otherwise infringe the licensor's copyright in it for any
+permitted purpose.  However, you may only distribute the
+software according to [Distribution License](#distribution-license)
+and make changes or new works based on the software according
+to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to
+distribute copies of the software.  Your license to distribute
+covers distributing the software with changes and new works
+permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.


### PR DESCRIPTION
## Summary

- Adds dual licensing structure for the Aquavate project
- Software components (firmware, iOS app) licensed under PolyForm Noncommercial 1.0.0
- Hardware designs and documentation licensed under CC BY-NC-SA 4.0
- Includes main LICENSE.md explaining the dual-license structure and usage terms

## Files Added

| File | Purpose |
|------|---------|
| `LICENSE.md` | Main overview with human-readable summary |
| `licenses/POLYFORM-NONCOMMERCIAL-1.0.0.txt` | Full PolyForm NC license for software |
| `licenses/CC-BY-NC-SA-4.0.txt` | CC license summary with official URL reference |

## Test plan

- [ ] Verify LICENSE.md renders correctly on GitHub
- [ ] Verify links to license files work
- [ ] Confirm commercial licensing contact link points to correct issues page

🤖 Generated with [Claude Code](https://claude.ai/code)