### PR TITLE
Persist daily goal to UserDefaults (Issue #31)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,54 +1,27 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-01-22
-**Current Branch:** `shake-to-empty-toggle`
+**Last Updated:** 2026-01-23
+**Current Branch:** `persist-daily-goal`
 
 ---
 
 ## Current Task
 
-**Shake-to-Empty Toggle Setting (Issue #32)** - [Plan 036](Plans/036-shake-to-empty-toggle.md)
-
-Add a toggle in iOS Settings to enable/disable the shake-to-empty gesture. The setting syncs to firmware via BLE and persists in NVS.
-
-### Progress
-
-- [x] Plan created and approved
-- [x] Branch created: `shake-to-empty-toggle` (from `watch-hydration-reminders`)
-- [x] **Task 1: Firmware Storage** - Add NVS functions for shake_empty_en setting
-  - Added `storageSaveShakeToEmptyEnabled()` and `storageLoadShakeToEmptyEnabled()` to storage.h/cpp
-  - NVS key: `shake_empty_en`, default: true (enabled)
-- [x] **Task 2: Firmware BLE Service** - Add Device Settings characteristic
-  - Added UUID `AQUAVATE_DEVICE_SETTINGS_UUID` (0006)
-  - Added `BLE_DeviceSettings` struct with flags field
-  - Added `DeviceSettingsCallbacks` class with onRead/onWrite
-  - Added `bleGetShakeToEmptyEnabled()` public function
-- [x] **Task 3: Firmware Main Loop** - Check setting before acting on shake gesture
-  - Modified main.cpp ~line 1037 to check `bleGetShakeToEmptyEnabled()` before setting `g_cancel_drink_pending`
-- [x] **Task 4: iOS BLE Constants** - Add deviceSettingsUUID
-  - Added `deviceSettingsUUID` to BLEConstants.swift
-  - Added to `aquavateCharacteristics` array
-  - Added `DeviceSettingsFlags` OptionSet
-- [x] **Task 5: iOS BLE Structs** - Add BLEDeviceSettings struct
-  - Added `BLEDeviceSettings` struct with parse/toData/create methods
-- [x] **Task 6: iOS BLE Manager** - Add property, handler, and write method
-  - Added `@Published var isShakeToEmptyEnabled: Bool = true`
-  - Added `deviceSettingsUUID` to required characteristics in `checkDiscoveryComplete()`
-  - Added case for `deviceSettingsUUID` in `didUpdateValueFor` switch
-  - Added `handleDeviceSettingsUpdate()` private method
-  - Added `setShakeToEmptyEnabled(_:)` public method
-- [x] **Task 7: iOS Settings UI** - Add toggle in Gestures section
-  - Added "Gestures" section in SettingsView.swift (visible when connected)
-  - Toggle for "Shake to Empty" with description
-- [x] Build and test firmware
-- [x] Build iOS app
-
-### Remaining
-- [ ] Integration testing (manual - upload firmware and test with iOS app)
+None - ready for next task.
 
 ---
 
 ## Recently Completed
+
+- ✅ Persist Daily Goal When Disconnected (Issue #31) - [Plan 037](Plans/037-persist-daily-goal.md)
+  - Fixed iOS app displaying hardcoded 2000 mL goal when disconnected
+  - Added `didSet` observer to persist `dailyGoalMl` to UserDefaults
+  - Restored goal from UserDefaults on app launch
+  - Follows existing `lastSyncTime` persistence pattern
+
+- ✅ Shake-to-Empty Toggle Setting (Issue #32) - [Plan 036](Plans/036-shake-to-empty-toggle.md)
+  - Added toggle in iOS Settings to enable/disable shake-to-empty gesture
+  - Setting syncs to firmware via BLE and persists in NVS
 
 - ✅ Extended Awake Duration for Unsynced Records (Issue #24) - [Plan 035](Plans/035-extended-awake-unsynced.md)
   - Re-introduced 4-minute extended timeout when unsynced records exist

--- a/Plans/037-persist-daily-goal.md
+++ b/Plans/037-persist-daily-goal.md
@@ -1,0 +1,68 @@
+# Plan: Fix Hardcoded 2000 mL Goal When Disconnected (Issue #31)
+
+## Problem Summary
+
+The iOS app displays a hardcoded 2000 mL hydration goal when disconnected from the bottle, instead of using the user's previously synced goal. This happens because:
+
+1. `BLEManager.dailyGoalMl` is initialized to `2000` (hardcoded default)
+2. When connected, this value is updated from the device's BLE Bottle Config
+3. If the app is **restarted while disconnected**, the goal resets to 2000 mL because there's no persistence
+
+## Root Cause
+
+In [BLEManager.swift:112](ios/Aquavate/Aquavate/Services/BLEManager.swift#L112):
+```swift
+@Published private(set) var dailyGoalMl: Int = 2000
+```
+
+The goal is only updated when the device sends a Bottle Config update. There's no mechanism to persist and restore the goal across app launches.
+
+## Solution
+
+Persist `dailyGoalMl` to `UserDefaults` using a `didSet` observer (matching the existing `lastSyncTime` pattern at line 134), and restore it in `init()`.
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| [BLEManager.swift](ios/Aquavate/Aquavate/Services/BLEManager.swift) | Add UserDefaults persistence for goal |
+
+### Implementation Steps
+
+1. **Add `didSet` observer to `dailyGoalMl`** (line 112):
+   ```swift
+   /// Daily goal in ml (from config)
+   @Published private(set) var dailyGoalMl: Int = 2000 {
+       didSet {
+           // Persist to UserDefaults for offline display
+           UserDefaults.standard.set(dailyGoalMl, forKey: "lastKnownDailyGoalMl")
+       }
+   }
+   ```
+
+2. **Restore goal in `init()`** (after line 206, following `lastSyncTime` pattern):
+   ```swift
+   // Load persisted daily goal (default 2000 if never synced)
+   if UserDefaults.standard.object(forKey: "lastKnownDailyGoalMl") != nil {
+       dailyGoalMl = UserDefaults.standard.integer(forKey: "lastKnownDailyGoalMl")
+   }
+   ```
+
+That's it - no other changes needed. The `didSet` automatically persists whenever `dailyGoalMl` is updated (from `handleBottleConfigUpdate()` or `writeBottleConfig()`).
+
+## Verification
+
+1. **Build the iOS app** in Xcode
+2. **Connect to the bottle** and verify goal syncs from device
+3. **Note the goal value** displayed in the app
+4. **Force-quit the app** (swipe up from app switcher)
+5. **Turn off the bottle** or move out of range
+6. **Relaunch the app** while disconnected
+7. **Verify** the goal shows the last synced value, not 2000 mL
+
+## Notes
+
+- Follows existing `lastSyncTime` pattern (lines 134-141, 206)
+- UserDefaults is appropriate for this single value
+- The 2000 mL default remains as fallback for first-time users
+- No changes needed to `handleBottleConfigUpdate()` or `writeBottleConfig()` - the `didSet` handles all cases

--- a/ios/Aquavate/Aquavate/Services/BLEManager.swift
+++ b/ios/Aquavate/Aquavate/Services/BLEManager.swift
@@ -109,7 +109,12 @@ class BLEManager: NSObject, ObservableObject {
     @Published private(set) var bottleCapacityMl: Int = 830
 
     /// Daily goal in ml (from config)
-    @Published private(set) var dailyGoalMl: Int = 2000
+    @Published private(set) var dailyGoalMl: Int = 2000 {
+        didSet {
+            // Persist to UserDefaults for offline display
+            UserDefaults.standard.set(dailyGoalMl, forKey: "lastKnownDailyGoalMl")
+        }
+    }
 
     // MARK: - Published Properties (Device Settings)
 
@@ -204,6 +209,11 @@ class BLEManager: NSObject, ObservableObject {
 
         // Load persisted last sync time
         lastSyncTime = UserDefaults.standard.object(forKey: "lastSyncTime") as? Date
+
+        // Load persisted daily goal (default 2000 if never synced)
+        if UserDefaults.standard.object(forKey: "lastKnownDailyGoalMl") != nil {
+            dailyGoalMl = UserDefaults.standard.integer(forKey: "lastKnownDailyGoalMl")
+        }
 
         let options: [String: Any] = [
             CBCentralManagerOptionRestoreIdentifierKey: BLEConstants.centralManagerRestoreIdentifier,


### PR DESCRIPTION
## Summary

Fixes #31 - iOS app displays hardcoded 2000 mL goal when disconnected from bottle.

- Added `didSet` observer to `dailyGoalMl` to persist to UserDefaults
- Restored goal from UserDefaults on app launch in `init()`
- Follows existing `lastSyncTime` persistence pattern

See [Plan 037](Plans/037-persist-daily-goal.md) for full details.

## Test Plan

- [x] Built iOS app in Xcode
- [x] Connected to bottle, verified goal syncs from device
- [x] Force-quit app (swipe up from app switcher)
- [x] Turned off bottle / moved out of range
- [x] Relaunched app while disconnected
- [x] Verified goal shows last synced value, not 2000 mL

🤖 Generated with [Claude Code](https://claude.com/claude-code)