### PR TITLE
Persist activity stats in CoreData for offline viewing (Issue #36)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,7 @@
 # Aquavate - Active Development Progress
 
 **Last Updated:** 2026-01-24
-**Current Branch:** `master` (after merge)
+**Current Branch:** `master`
 
 ---
 
@@ -15,13 +15,18 @@ No active task. Ready for next issue.
 
 To resume from this progress file:
 ```
-Continue from PROGRESS.md.
-No active task - ready for next issue.
+Resume from PROGRESS.md.
+No active task - check GitHub issues for next work item.
 ```
 
 ---
 
 ## Recently Completed
+
+- ✅ Local Activity Stats Storage (Issue #36 Comment) - [Plan 040](Plans/040-local-activity-stats-storage.md)
+  - Activity stats (motion wake events, backpack sessions) now persist in CoreData
+  - Users can view data even when disconnected with "Last synced X ago" timestamp
+  - Fixed: Diagnostics section accessible when disconnected in SettingsView
 
 - ✅ Fix Duplicate HealthKit Entries (Issue #37) - [Plan 039](Plans/039-fix-duplicate-healthkit-entries.md)
   - Race condition in `syncDrinksToHealthKit()` caused multiple HealthKit entries

--- a/Plans/040-local-activity-stats-storage.md
+++ b/Plans/040-local-activity-stats-storage.md
@@ -1,0 +1,99 @@
+# Plan: Local Activity Stats Storage (Issue #36 Comment)
+
+## Status: Complete ✅
+
+Implemented 2026-01-24. Activity stats (motion wake events, backpack sessions) now persist in CoreData. Users can view this data even when disconnected, with a "Last synced X ago" timestamp.
+
+## Overview
+Store activity stats (motion wake events, backpack sessions) locally in CoreData so users can view this data even when the bottle is disconnected. This mirrors the existing pattern used for drink records.
+
+## Current State
+- **ActivityStatsView** shows "Connect to bottle to view activity stats" when disconnected
+- Data lives only in BLEManager's in-memory arrays (`motionWakeEvents`, `backpackSessions`)
+- Data is lost when app restarts or bottle disconnects
+
+## Implementation
+
+### 1. Add CoreData Entities
+**File:** [Aquavate.xcdatamodel/contents](ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/Aquavate.xcdatamodel/contents)
+
+Add two new entities:
+
+**CDMotionWakeEvent:**
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| id | UUID | App's internal ID |
+| timestamp | Date | When wake occurred |
+| durationSec | Int16 | How long device stayed awake |
+| wakeReason | Int16 | 0=motion, 1=timer, 2=power_on |
+| sleepType | Int16 | 0=normal, 1=extended |
+| drinkTaken | Bool | Whether a drink was taken during this wake |
+| bottleId | UUID | Reference to bottle |
+
+Uniqueness constraint: `(timestamp, bottleId)`
+
+**CDBackpackSession:**
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| id | UUID | App's internal ID |
+| startTimestamp | Date | When session started |
+| durationSec | Int32 | Total time in backpack mode |
+| timerWakeCount | Int16 | Number of timer wakes during session |
+| exitReason | Int16 | 0=motion_detected, 1=still_active, 2=power_cycle |
+| bottleId | UUID | Reference to bottle |
+
+Uniqueness constraint: `(startTimestamp, bottleId)`
+
+Add relationships to CDBottle:
+- `motionWakeEvents` (to-many, cascade delete)
+- `backpackSessions` (to-many, cascade delete)
+
+Also add to CDBottle:
+- `lastActivitySyncDate: Date` - when activity stats were last synced
+
+### 2. Add Persistence Methods
+**File:** [PersistenceController.swift](ios/Aquavate/Aquavate/CoreData/PersistenceController.swift)
+
+Add methods following the existing `saveDrinkRecords` pattern:
+
+```swift
+func saveMotionWakeEvents(_ events: [BLEMotionWakeEvent], for bottleId: UUID)
+func saveBackpackSessions(_ sessions: [BLEBackpackSession], for bottleId: UUID)
+func clearActivityStats(for bottleId: UUID)  // Clear before re-sync
+func updateLastActivitySyncDate(for bottleId: UUID)
+```
+
+### 3. Update BLEManager
+**File:** [BLEManager.swift](ios/Aquavate/Aquavate/Services/BLEManager.swift)
+
+After activity fetch completes (in the existing fetch flow):
+1. Clear existing activity stats for bottle (fresh sync each time)
+2. Save motion wake events to CoreData
+3. Save backpack sessions to CoreData
+4. Update `lastActivitySyncDate` on bottle
+
+### 4. Update ActivityStatsView
+**File:** [ActivityStatsView.swift](ios/Aquavate/Aquavate/Views/ActivityStatsView.swift)
+
+Changes:
+- Add `@FetchRequest` for CDMotionWakeEvent and CDBackpackSession
+- Remove dependency on `bleManager.motionWakeEvents` and `bleManager.backpackSessions`
+- When disconnected: show cached data from CoreData with "Last synced: X ago" header
+- When connected: trigger fetch, which updates CoreData, which updates view via @FetchRequest
+- Keep pull-to-refresh for manual refresh when connected
+
+### 5. Update Preview Provider
+Add sample activity data to `PersistenceController.preview` for SwiftUI previews.
+
+## Files to Modify
+1. [Aquavate.xcdatamodel/contents](ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/Aquavate.xcdatamodel/contents) - Add entities
+2. [PersistenceController.swift](ios/Aquavate/Aquavate/CoreData/PersistenceController.swift) - Add save methods
+3. [BLEManager.swift](ios/Aquavate/Aquavate/Services/BLEManager.swift) - Save after fetch
+4. [ActivityStatsView.swift](ios/Aquavate/Aquavate/Views/ActivityStatsView.swift) - Use CoreData
+
+## Verification
+1. Build the iOS app successfully
+2. Connect to bottle and fetch activity stats - verify data saves to CoreData
+3. Disconnect bottle - verify cached data still displays
+4. Reconnect and pull-to-refresh - verify data updates
+5. Force quit and relaunch app while disconnected - verify data persists

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -1,10 +1,11 @@
 # Aquavate iOS App - UX Product Requirements Document
 
-**Version:** 1.9
+**Version:** 1.10
 **Date:** 2026-01-24
-**Status:** Approved and Tested (Hydration Reminders + Watch App)
+**Status:** Approved and Tested (Activity Stats Persistence)
 
 **Changelog:**
+- **v1.10 (2026-01-24):** Activity Stats now persist in CoreData (Issue #36 Comment). Users can view cached data when disconnected with "Last synced X ago" timestamp. Diagnostics section accessible when disconnected.
 - **v1.9 (2026-01-24):** Added Hydration Reminders with pace-based urgency model (Issue #27). Added Apple Watch companion app with complications. Added target intake visualization on HomeView. See Section 2.8 (Watch App) and Section 7 (Notification Strategy).
 - **v1.8 (2026-01-23):** Added Diagnostics section to Settings with Activity Stats view (Issue #36). Shows motion wake events and backpack sessions for battery analysis. Includes "drink taken" indicator (water drop icon) for wakes where user took a drink.
 - **v1.7 (2026-01-23):** Added Gestures section to Settings with Shake-to-Empty toggle. Setting syncs to firmware via BLE Device Settings characteristic.
@@ -617,16 +618,18 @@ Aquavate uses a **4am daily reset** while Apple Health uses **midnight**. This m
 
 **Behavior:**
 - **Lazy loading:** Data fetched only when view appears (not on app launch)
-- **Pull-to-refresh:** Re-fetches all activity data
-- **Disconnected state:** Shows "Connect to bottle to view activity stats" message
+- **Pull-to-refresh:** Re-fetches all activity data (requires connection)
+- **Disconnected state:** Shows cached data from CoreData with "Last synced X ago" timestamp
 - **Loading state:** Progress indicator while fetching chunks
+- **Persistence:** Data stored in CoreData entities (CDMotionWakeEvent, CDBackpackSession)
 
 **Edge Cases:**
 
 | Scenario | Behavior |
 |----------|----------|
-| Not connected | Shows connection required message |
-| No activity data | Shows "No activity recorded since last charge" |
+| Not connected (with cached data) | Shows cached data with "Last synced X ago" timestamp |
+| Not connected (no cached data) | Shows "No activity data. Connect to bottle to sync." |
+| No activity data (connected) | Shows "No activity recorded since last charge" |
 | Fetch error | Shows error message with retry option |
 | In backpack mode | Shows current session start time and timer wake count |
 
@@ -1742,7 +1745,7 @@ Watch notifications include haptic feedback via `WKInterfaceDevice.current().pla
 | Home Screen | ✅ Complete | 4.2-4.6 | Wire BLE data, target visualization (Issue #27) |
 | History Screen | ✅ Complete | 4.3-4.4 | Wire CoreData |
 | Settings Screen | ✅ Complete | 4.2-4.5 | Calibrate, Diagnostics, Hydration Reminders |
-| Activity Stats | ✅ Complete | - | Battery diagnostics (Issue #36, 2026-01-23) |
+| Activity Stats | ✅ Complete | - | Battery diagnostics with offline support (Issue #36, 2026-01-24) |
 | Watch App | ✅ Complete | - | Companion app + complications (Issue #27, 2026-01-24) |
 
 | Component | Status | Phase |
@@ -1760,7 +1763,13 @@ Watch notifications include haptic feedback via `WKInterfaceDevice.current().pla
 
 This UX PRD defines the complete user experience for the Aquavate iOS app. Upon approval, Phase 4 implementation will begin following both this document and the technical plan in [Plans/014-ios-ble-coredata-integration.md](../Plans/014-ios-ble-coredata-integration.md).
 
-**Document Status:** Approved (v1.9)
+**Document Status:** Approved (v1.10)
+
+**Update Note (2026-01-24 - Activity Stats Persistence):**
+- Activity stats now persist in CoreData (Issue #36 Comment)
+- Users can view cached data when disconnected with "Last synced X ago" timestamp
+- Diagnostics section accessible when disconnected in SettingsView
+- Follows existing drink record persistence pattern
 
 **Update Note (2026-01-24 - Hydration Reminders + Watch App):**
 - Added pace-based hydration reminder system (Issue #27)
@@ -1817,5 +1826,6 @@ This UX PRD defines the complete user experience for the Aquavate iOS app. Upon 
 3. ✅ Bidirectional drink sync (Complete - 2026-01-21)
 4. ✅ HealthKit integration (Complete - 2026-01-21)
 5. ✅ Hydration Reminders + Apple Watch App (Complete - 2026-01-24, Issue #27)
-6. Phase 4.7 implementation (Calibration Wizard) - Optional/Future
-7. Begin Phase 5 (Advanced features)
+6. ✅ Activity Stats Persistence (Complete - 2026-01-24, Issue #36 Comment)
+7. Phase 4.7 implementation (Calibration Wizard) - Optional/Future
+8. Begin Phase 5 (Advanced features)

--- a/ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/Aquavate.xcdatamodel/contents
+++ b/ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/Aquavate.xcdatamodel/contents
@@ -1,17 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="24C5089c" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="NO" userDefinedModelVersionIdentifier="">
+    <entity name="CDBackpackSession" representedClassName="CDBackpackSession" syncable="YES" codeGenerationType="class">
+        <attribute name="bottleId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="durationSec" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="exitReason" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="startTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="timerWakeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="bottle" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDBottle" inverseName="backpackSessions" inverseEntity="CDBottle"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="startTimestamp"/>
+                <constraint value="bottleId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
     <entity name="CDBottle" representedClassName="CDBottle" syncable="YES" codeGenerationType="class">
         <attribute name="batteryPercent" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="capacityMl" optional="YES" attributeType="Integer 16" defaultValueString="750" usesScalarValueType="YES"/>
         <attribute name="dailyGoalMl" optional="YES" attributeType="Integer 16" defaultValueString="2000" usesScalarValueType="YES"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isCalibrated" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastActivitySyncDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lastSyncDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String" defaultValueString="My Bottle"/>
         <attribute name="peripheralIdentifier" optional="YES" attributeType="String"/>
         <attribute name="scaleFactor" optional="YES" attributeType="Float" defaultValueString="1.0" usesScalarValueType="YES"/>
         <attribute name="tareWeightGrams" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="backpackSessions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDBackpackSession" inverseName="bottle" inverseEntity="CDBackpackSession"/>
         <relationship name="drinkRecords" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDDrinkRecord" inverseName="bottle" inverseEntity="CDDrinkRecord"/>
+        <relationship name="motionWakeEvents" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDMotionWakeEvent" inverseName="bottle" inverseEntity="CDMotionWakeEvent"/>
     </entity>
     <entity name="CDDrinkRecord" representedClassName="CDDrinkRecord" syncable="YES" codeGenerationType="class">
         <attribute name="amountMl" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
@@ -24,6 +42,22 @@
         <attribute name="syncedToHealth" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="bottle" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDBottle" inverseName="drinkRecords" inverseEntity="CDBottle"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="timestamp"/>
+                <constraint value="bottleId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CDMotionWakeEvent" representedClassName="CDMotionWakeEvent" syncable="YES" codeGenerationType="class">
+        <attribute name="bottleId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="drinkTaken" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="durationSec" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="sleepType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="wakeReason" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="bottle" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDBottle" inverseName="motionWakeEvents" inverseEntity="CDBottle"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="timestamp"/>

--- a/ios/Aquavate/Aquavate/Views/SettingsView.swift
+++ b/ios/Aquavate/Aquavate/Views/SettingsView.swift
@@ -343,25 +343,26 @@ struct SettingsView: View {
                         }
                     }
 
-                    // Activity Stats (Battery Analysis)
-                    Section("Diagnostics") {
-                        NavigationLink {
-                            ActivityStatsView()
-                        } label: {
-                            HStack {
-                                Image(systemName: "moon.zzz")
-                                    .foregroundStyle(.purple)
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text("Sleep Mode Analysis")
-                                    Text("View wake events and backpack sessions")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                                Spacer()
-                                if bleManager.activityFetchState.isLoading {
-                                    ProgressView()
-                                        .scaleEffect(0.7)
-                                }
+                }
+
+                // Activity Stats (Battery Analysis) - Outside connected block for offline viewing
+                Section("Diagnostics") {
+                    NavigationLink {
+                        ActivityStatsView()
+                    } label: {
+                        HStack {
+                            Image(systemName: "moon.zzz")
+                                .foregroundStyle(.purple)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Sleep Mode Analysis")
+                                Text("View wake events and backpack sessions")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            if bleManager.activityFetchState.isLoading {
+                                ProgressView()
+                                    .scaleEffect(0.7)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Activity stats (motion wake events, backpack sessions) now persist locally in CoreData
- Users can view cached data even when bottle is disconnected
- Mirrors existing drink records persistence pattern

## Implementation
- Added CoreData entities: `CDMotionWakeEvent`, `CDBackpackSession`
- Added `lastActivitySyncDate` to CDBottle for sync tracking
- ActivityStatsView uses `@FetchRequest` to display data from CoreData
- When disconnected, shows cached data with "Last synced X ago" timestamp
- Fixed: Diagnostics section now accessible when disconnected in SettingsView

## Test plan
- [x] Connect to bottle and fetch activity stats - verify data saves to CoreData
- [x] Disconnect bottle - verify cached data still displays with sync timestamp
- [x] Reconnect and pull-to-refresh - verify data updates
- [x] Force quit and relaunch app while disconnected - verify data persists

See [Plans/040-local-activity-stats-storage.md](Plans/040-local-activity-stats-storage.md) for full implementation details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)