### PR TITLE
Fix HomeView pull-to-refresh 'Bottle is Asleep' alert (Issue #44)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,28 +7,7 @@
 
 ## Current Task
 
-**Issue:** #44 - HomeView pull-to-refresh fails to show 'Bottle is Asleep' alert
-**Plan:** [041-fix-homeview-refresh-alert.md](Plans/041-fix-homeview-refresh-alert.md)
-**Branch:** `fix-homeview-refresh-alert`
-
-### Problem
-HomeView's pull-to-refresh sometimes fails to show the "Bottle is Asleep" alert when bottle can't be found. HistoryView correctly shows the alert in the same scenario. Issue appears after extended use; restarting fixes it.
-
-### Root Cause
-`stopScanning()` has a guard that returns early if `centralManager.isScanning` is false, leaving `connectionState` stuck as `.scanning` when iOS stops scanning externally.
-
-### Implementation Progress
-
-- [x] **Change 1:** Fix `stopScanning()` (Lines 325-336) - Always clean up state
-- [x] **Change 2:** Add defensive recovery in `startScanning()` (Lines 292-302)
-- [x] **Change 3:** Improve `handleScanTimeout()` robustness (Lines 598-606)
-- [x] **Change 4:** Add diagnostic logging to `attemptConnection()` (Lines 1775-1812)
-- [x] **Change 5:** Clean up scanning state on Bluetooth transitions (Lines 668-670)
-- [x] **Change 6:** Add direct scan timeout check in polling loop (bypass Timer Task race condition)
-- [x] **Build:** iOS app builds successfully
-
-### Files to Modify
-- `ios/Aquavate/Aquavate/Services/BLEManager.swift`
+None - awaiting next issue.
 
 ---
 
@@ -37,12 +16,18 @@ HomeView's pull-to-refresh sometimes fails to show the "Bottle is Asleep" alert 
 To resume from this progress file:
 ```
 Resume from PROGRESS.md.
-No active task - check GitHub issues for next work item.
+Issue #44 fix complete - all tests pass. Ready to commit and create PR.
 ```
 
 ---
 
 ## Recently Completed
+
+- ✅ Fix HomeView Refresh Alert (Issue #44) - [Plan 041](Plans/041-fix-homeview-refresh-alert.md)
+  - Fixed race condition in BLEManager where `stopScanning()` guard caused corrupted state
+  - Refactored `attemptConnection()` to use elapsed time for `.bottleAsleep` detection
+  - Added defensive state recovery and cleanup on Bluetooth transitions
+  - Tested: All 5 verification scenarios pass consistently
 
 - ✅ Local Activity Stats Storage (Issue #36 Comment) - [Plan 040](Plans/040-local-activity-stats-storage.md)
   - Activity stats (motion wake events, backpack sessions) now persist in CoreData
@@ -136,7 +121,7 @@ No active task - check GitHub issues for next work item.
 ## Branch Status
 
 - `master` - Stable baseline
-- `fix-homeview-refresh-alert` - Issue #44 (in progress)
+- `fix-homeview-refresh-alert` - Issue #44 (PR pending)
 
 ---
 

--- a/Plans/041-fix-homeview-refresh-alert.md
+++ b/Plans/041-fix-homeview-refresh-alert.md
@@ -210,3 +210,27 @@ case .resetting:
 1. With bottle asleep, refresh on HomeView - note result
 2. Refresh on HistoryView - note result
 3. **Expected:** Both show identical "Bottle is Asleep" alert
+
+---
+
+## Completion
+
+**Status:** ✅ Complete (2026-01-24)
+
+**Implementation Summary:**
+All five changes implemented in BLEManager.swift:
+1. Fixed `stopScanning()` to always clean up state even when CoreBluetooth stopped externally
+2. Added defensive state recovery in `startScanning()` to detect/fix corrupted state
+3. Simplified `handleScanTimeout()` to just stop the scan (no error message dependency)
+4. Refactored `attemptConnection()` to use elapsed time for `.bottleAsleep` detection instead of Timer callbacks
+5. Added scanning state cleanup on Bluetooth `.resetting` transition
+
+**Tests Performed:**
+- ✅ Test 1: Basic refresh - connects and syncs successfully
+- ✅ Test 2: Bottle asleep alert - shows correctly after ~10 seconds
+- ✅ Test 3: State recovery after Bluetooth toggle - shows correct alert
+- ✅ Test 4: Extended use simulation - consistent behavior
+- ✅ Test 5: HomeView/HistoryView parity - identical behavior on both views
+
+**Key Insight:**
+The original design had a race condition where `attemptConnection()` relied on the Timer callback to set `errorMessage` before checking scan timeout. The refactored design uses elapsed time directly (`Date().timeIntervalSince(scanStart) > scanTimeout`) which is deterministic and doesn't depend on Timer scheduling.


### PR DESCRIPTION
## Summary
- Fixed race condition where `stopScanning()` guard left BLE state corrupted when iOS stopped scanning externally
- Refactored `attemptConnection()` to use elapsed time for bottle asleep detection instead of Timer callbacks
- Added defensive state recovery and cleanup on Bluetooth transitions

See [Plans/041-fix-homeview-refresh-alert.md](Plans/041-fix-homeview-refresh-alert.md) for full root cause analysis and implementation details.

## Test plan
- [x] Basic refresh: App connects and syncs successfully when bottle is awake
- [x] Bottle asleep alert: Shows "Bottle is Asleep" alert after ~10 seconds when bottle is in deep sleep
- [x] State recovery: Correct alert shown after Bluetooth toggle off/on
- [x] Extended use: Consistent behavior after multiple connect/disconnect cycles and app backgrounding
- [x] HomeView/HistoryView parity: Both views show identical "Bottle is Asleep" alert

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)