### PR TITLE
Add daily reminder limit toggle (Issue #45)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,7 @@
 # Aquavate - Active Development Progress
 
 **Last Updated:** 2026-01-24
-**Current Branch:** `fix-homeview-refresh-alert`
+**Current Branch:** `master`
 
 ---
 
@@ -16,12 +16,16 @@ None - awaiting next issue.
 To resume from this progress file:
 ```
 Resume from PROGRESS.md.
-Issue #44 fix complete - all tests pass. Ready to commit and create PR.
 ```
 
 ---
 
 ## Recently Completed
+
+- ✅ Daily Reminder Limit Toggle (Issue #45) - [Plan 042](Plans/042-daily-reminder-limit-toggle.md)
+  - Added "Limit Daily Reminders" toggle to Settings → Hydration Reminders
+  - When disabled, allows unlimited reminders (respects quiet hours and escalation)
+  - Fixed back-on-track notification timing bug (was using stale urgency data)
 
 - ✅ Fix HomeView Refresh Alert (Issue #44) - [Plan 041](Plans/041-fix-homeview-refresh-alert.md)
   - Fixed race condition in BLEManager where `stopScanning()` guard caused corrupted state
@@ -121,7 +125,6 @@ Issue #44 fix complete - all tests pass. Ready to commit and create PR.
 ## Branch Status
 
 - `master` - Stable baseline
-- `fix-homeview-refresh-alert` - Issue #44 (PR pending)
 
 ---
 

--- a/Plans/042-daily-reminder-limit-toggle.md
+++ b/Plans/042-daily-reminder-limit-toggle.md
@@ -1,0 +1,154 @@
+# Plan: Add Daily Reminder Limit Toggle (Issue #45)
+
+## Summary
+Add a toggle in Settings to enable/disable the daily hydration reminder limit (currently hardcoded at 12/day). Also fix back-on-track notification timing bug.
+
+## Files to Modify
+
+1. **[NotificationManager.swift](ios/Aquavate/Aquavate/Services/NotificationManager.swift)**
+2. **[SettingsView.swift](ios/Aquavate/Aquavate/Views/SettingsView.swift)**
+3. **[BLEManager.swift](ios/Aquavate/Aquavate/Services/BLEManager.swift)**
+4. **[HydrationReminderService.swift](ios/Aquavate/Aquavate/Services/HydrationReminderService.swift)**
+
+---
+
+## Implementation Steps
+
+### Step 1: Add `dailyLimitEnabled` Property to NotificationManager
+
+**File:** [NotificationManager.swift](ios/Aquavate/Aquavate/Services/NotificationManager.swift)
+
+Add a new published property (after `backOnTrackEnabled` around line 40):
+
+```swift
+@Published var dailyLimitEnabled: Bool {
+    didSet {
+        UserDefaults.standard.set(dailyLimitEnabled, forKey: "dailyReminderLimitEnabled")
+    }
+}
+```
+
+Initialize it in `init()` (around line 55):
+
+```swift
+self.dailyLimitEnabled = UserDefaults.standard.object(forKey: "dailyReminderLimitEnabled") as? Bool ?? true
+```
+
+Note: Default to `true` to preserve existing behavior.
+
+### Step 2: Modify `canSendReminder` to Respect Toggle
+
+**File:** [NotificationManager.swift:138-142](ios/Aquavate/Aquavate/Services/NotificationManager.swift#L138-L142)
+
+Update the computed property:
+
+```swift
+var canSendReminder: Bool {
+    checkDailyReset()
+    guard dailyLimitEnabled else { return true }
+    return remindersSentToday < Self.maxRemindersPerDay
+}
+```
+
+### Step 3: Add Toggle UI in SettingsView
+
+**File:** [SettingsView.swift](ios/Aquavate/Aquavate/Views/SettingsView.swift)
+
+Add new toggle after "Reminders Today" display (after line 459, before "Back On Track Alerts"):
+
+```swift
+Toggle(isOn: $notificationManager.dailyLimitEnabled) {
+    HStack {
+        Image(systemName: "number.circle")
+            .foregroundStyle(.blue)
+        Text("Limit Daily Reminders")
+    }
+}
+```
+
+### Step 4: Make "Reminders Today" Display Conditional
+
+**File:** [SettingsView.swift:451-459](ios/Aquavate/Aquavate/Views/SettingsView.swift#L451-L459)
+
+Update to show limit only when enabled, otherwise show just the count:
+
+```swift
+HStack {
+    Image(systemName: "bell.badge")
+        .foregroundStyle(.secondary)
+    Text("Reminders Today")
+    Spacer()
+    if notificationManager.dailyLimitEnabled {
+        Text("\(notificationManager.remindersSentToday)/\(NotificationManager.maxRemindersPerDay)")
+            .foregroundStyle(.secondary)
+            .font(.subheadline)
+    } else {
+        Text("\(notificationManager.remindersSentToday)")
+            .foregroundStyle(.secondary)
+            .font(.subheadline)
+    }
+}
+```
+
+### Step 5: Fix Back-on-Track Notification Timing
+
+**Bug:** The back-on-track notification was not sent immediately because `drinkRecorded()` was called before `updateState()`, so it was using stale urgency values.
+
+**File:** [BLEManager.swift](ios/Aquavate/Aquavate/Services/BLEManager.swift)
+
+In `processSyncedRecords()`, capture previous urgency before state update:
+
+```swift
+// Capture previous urgency before updating state for back-on-track detection
+let previousUrgency = hydrationReminderService?.currentUrgency
+
+// Update hydration state (this recalculates urgency)
+hydrationReminderService?.updateState(
+    totalMl: dailyTotalMl,
+    goalMl: dailyGoalMl,
+    lastDrink: Date()
+)
+
+// Check for back-on-track transition
+hydrationReminderService?.checkBackOnTrack(previousUrgency: previousUrgency)
+```
+
+**File:** [HydrationReminderService.swift](ios/Aquavate/Aquavate/Services/HydrationReminderService.swift)
+
+Rename `drinkRecorded()` to `checkBackOnTrack(previousUrgency:)`:
+
+```swift
+func checkBackOnTrack(previousUrgency: HydrationUrgency?) {
+    guard let previousUrgency = previousUrgency else { return }
+
+    if previousUrgency > .onTrack && currentUrgency == .onTrack {
+        // Send back-on-track notification
+        notificationManager?.scheduleBackOnTrackNotification()
+        // ... watch notification code
+    }
+}
+```
+
+---
+
+## UI Result
+
+```
+Hydration Reminders
+├─ [Toggle] Hydration Reminders
+├─ Status: Authorized
+├─ Current Status: On Track
+├─ Reminders Today: 3/12      (or just "3" when limit disabled)
+├─ [Toggle] Limit Daily Reminders    <-- NEW
+├─ [Toggle] Back On Track Alerts
+```
+
+---
+
+## Verification
+
+- [x] Build the app: No compilation errors
+- [x] Test toggle persistence: Toggle state persists across app restarts
+- [x] Test display update: Shows "3/12" with limit enabled, "3" when disabled
+- [x] Test default behavior: Fresh install has limit enabled by default
+- [ ] Test back-on-track notification: Get behind pace, drink to catch up, verify `[HydrationReminder] Back on track!` log appears immediately

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -1403,7 +1403,7 @@ Deficit = expected - dailyTotalMl
 **Configuration:**
 - Active hours: 7am-10pm (15 hours)
 - Quiet hours: 10pm-7am (no reminders)
-- Max 12 reminders per day
+- Max 12 reminders per day (configurable via "Limit Daily Reminders" toggle)
 - 50ml rounding: Deficits rounded to nearest 50ml, suppressed if <50ml
 - Escalation model: Only notify when urgency increases (no repeated same-level notifications)
 
@@ -1419,6 +1419,7 @@ Deficit = expected - dailyTotalMl
 
 **Settings (SettingsView):**
 - Hydration Reminders toggle (main on/off)
+- Limit Daily Reminders toggle (enforces 12/day max, enabled by default)
 - Back On Track Alerts toggle (optional, disabled by default)
 - Test Mode toggle (DEBUG only, lowers notification threshold)
 
@@ -1770,6 +1771,13 @@ This UX PRD defines the complete user experience for the Aquavate iOS app. Upon 
 - Users can view cached data when disconnected with "Last synced X ago" timestamp
 - Diagnostics section accessible when disconnected in SettingsView
 - Follows existing drink record persistence pattern
+
+**Update Note (2026-01-24 - Daily Reminder Limit Toggle):**
+- Added "Limit Daily Reminders" toggle to Settings → Hydration Reminders (Issue #45)
+- When enabled (default): enforces 12 reminders/day maximum
+- When disabled: allows unlimited reminders (respects quiet hours and escalation)
+- "Reminders Today" display shows "X/12" when limit enabled, just "X" when disabled
+- Fixed back-on-track notification timing bug (was using stale urgency data)
 
 **Update Note (2026-01-24 - Hydration Reminders + Watch App):**
 - Added pace-based hydration reminder system (Issue #27)

--- a/ios/Aquavate/Aquavate/Services/BLEManager.swift
+++ b/ios/Aquavate/Aquavate/Services/BLEManager.swift
@@ -1300,13 +1300,18 @@ extension BLEManager: CBPeripheralDelegate {
         syncProgress = 1.0
         lastSyncTime = Date()
 
-        // Notify hydration reminder service that drinks were synced
-        hydrationReminderService?.drinkRecorded()
+        // Capture previous urgency before updating state for back-on-track detection
+        let previousUrgency = hydrationReminderService?.currentUrgency
+
+        // Update hydration state (this recalculates urgency)
         hydrationReminderService?.updateState(
             totalMl: dailyTotalMl,
             goalMl: dailyGoalMl,
             lastDrink: Date()  // Use current time as last drink since we just synced
         )
+
+        // Check for back-on-track transition
+        hydrationReminderService?.checkBackOnTrack(previousUrgency: previousUrgency)
 
         // Check if goal achieved
         if dailyTotalMl >= dailyGoalMl {

--- a/ios/Aquavate/Aquavate/Services/HydrationReminderService.swift
+++ b/ios/Aquavate/Aquavate/Services/HydrationReminderService.swift
@@ -129,13 +129,10 @@ class HydrationReminderService: ObservableObject {
         syncStateToWatch()
     }
 
-    /// Called after a drink is recorded (via BLE sync)
-    func drinkRecorded() {
-        lastDrinkTime = Date()
-
-        // Recalculate urgency - may still be behind pace even after drinking
-        let previousUrgency = currentUrgency
-        updateUrgency()
+    /// Check if we've transitioned back to on-track and send notification if so
+    /// - Parameter previousUrgency: The urgency level before the state update
+    func checkBackOnTrack(previousUrgency: HydrationUrgency?) {
+        guard let previousUrgency = previousUrgency else { return }
 
         // Check if back on track (was behind, now on track)
         if previousUrgency > .onTrack && currentUrgency == .onTrack {

--- a/ios/Aquavate/Aquavate/Services/NotificationManager.swift
+++ b/ios/Aquavate/Aquavate/Services/NotificationManager.swift
@@ -39,6 +39,13 @@ class NotificationManager: ObservableObject {
         }
     }
 
+    /// User preference for enforcing daily reminder limit
+    @Published var dailyLimitEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(dailyLimitEnabled, forKey: "dailyReminderLimitEnabled")
+        }
+    }
+
     /// Number of reminders sent today (resets at 4am)
     @Published private(set) var remindersSentToday: Int = 0
 
@@ -52,6 +59,7 @@ class NotificationManager: ObservableObject {
     init() {
         self.isEnabled = UserDefaults.standard.bool(forKey: "hydrationRemindersEnabled")
         self.backOnTrackEnabled = UserDefaults.standard.bool(forKey: "backOnTrackNotificationsEnabled")
+        self.dailyLimitEnabled = UserDefaults.standard.object(forKey: "dailyReminderLimitEnabled") as? Bool ?? true
         self.remindersSentToday = UserDefaults.standard.integer(forKey: "remindersSentToday")
         if let lastReset = UserDefaults.standard.object(forKey: "lastReminderResetDate") as? Date {
             self.lastResetDate = lastReset
@@ -138,6 +146,7 @@ class NotificationManager: ObservableObject {
     /// Check if we can send more reminders today
     var canSendReminder: Bool {
         checkDailyReset()
+        guard dailyLimitEnabled else { return true }
         return remindersSentToday < Self.maxRemindersPerDay
     }
 

--- a/ios/Aquavate/Aquavate/Views/SettingsView.swift
+++ b/ios/Aquavate/Aquavate/Views/SettingsView.swift
@@ -453,9 +453,23 @@ struct SettingsView: View {
                                 .foregroundStyle(.secondary)
                             Text("Reminders Today")
                             Spacer()
-                            Text("\(notificationManager.remindersSentToday)/\(NotificationManager.maxRemindersPerDay)")
-                                .foregroundStyle(.secondary)
-                                .font(.subheadline)
+                            if notificationManager.dailyLimitEnabled {
+                                Text("\(notificationManager.remindersSentToday)/\(NotificationManager.maxRemindersPerDay)")
+                                    .foregroundStyle(.secondary)
+                                    .font(.subheadline)
+                            } else {
+                                Text("\(notificationManager.remindersSentToday)")
+                                    .foregroundStyle(.secondary)
+                                    .font(.subheadline)
+                            }
+                        }
+
+                        Toggle(isOn: $notificationManager.dailyLimitEnabled) {
+                            HStack {
+                                Image(systemName: "number.circle")
+                                    .foregroundStyle(.blue)
+                                Text("Limit Daily Reminders")
+                            }
                         }
 
                         Toggle(isOn: $notificationManager.backOnTrackEnabled) {


### PR DESCRIPTION
## Summary

- Add "Limit Daily Reminders" toggle to Settings → Hydration Reminders
- Fix back-on-track notification timing bug

## Changes

- **NotificationManager.swift**: Added `dailyLimitEnabled` property with UserDefaults persistence, updated `canSendReminder` to bypass limit when disabled
- **SettingsView.swift**: Added toggle UI, made "Reminders Today" display conditional (shows "X/12" or just "X")
- **BLEManager.swift**: Fixed back-on-track notification timing by capturing previous urgency before state update
- **HydrationReminderService.swift**: Renamed `drinkRecorded()` to `checkBackOnTrack(previousUrgency:)` for correct urgency transition detection

See [Plans/042-daily-reminder-limit-toggle.md](Plans/042-daily-reminder-limit-toggle.md) for full implementation details.

## Test Plan

- [x] Build succeeds with no compilation errors
- [x] Toggle persistence: Setting persists across app restarts
- [x] Display update: Shows "3/12" with limit enabled, "3" when disabled
- [x] Default behavior: Fresh install has limit enabled by default
- [ ] Back-on-track notification: Pending hardware test (requires BLE sync while behind pace)

Closes #45

🤖 Generated with [Claude Code](https://claude.ai/code)