### PR TITLE
Fix orange overlay appearing when on track (Issue #48)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -22,6 +22,11 @@ Resume from PROGRESS.md.
 
 ## Recently Completed
 
+- ✅ Orange Line Rounding Fix (Issue #48) - [Plan 043](Plans/043-orange-line-rounding-fix.md)
+  - Fixed orange overlay appearing when user is "on track" (small deficit < 25ml)
+  - Changed overlay condition to use `isBehindTarget` (50ml rounded threshold)
+  - Ensures visual overlay and "behind target" text appear/disappear together
+
 - ✅ Daily Reminder Limit Toggle (Issue #45) - [Plan 042](Plans/042-daily-reminder-limit-toggle.md)
   - Added "Limit Daily Reminders" toggle to Settings → Hydration Reminders
   - When disabled, allows unlimited reminders (respects quiet hours and escalation)

--- a/Plans/043-orange-line-rounding-fix.md
+++ b/Plans/043-orange-line-rounding-fix.md
@@ -1,0 +1,41 @@
+# Plan: Fix Orange Line Rounding Issue (Issue #48) ✅ COMPLETE
+
+## Problem Summary
+
+A thin orange line appears above the blue fill in the human figure when the user is slightly behind pace (1-24ml), even though no "behind target" text is displayed. This creates confusing visual feedback.
+
+## Root Cause
+
+Inconsistent thresholds between visual overlay and text display:
+
+| Component | Condition | Threshold |
+|-----------|-----------|-----------|
+| Orange overlay | `expectedProgress > progress` | 1ml (exact comparison) |
+| "Behind target" text | `roundedDeficitMl >= 50` | 50ml (rounded) |
+
+Small deficits trigger the overlay but round to 0ml for text, causing the mismatch.
+
+## Implementation
+
+### File to Modify
+
+`ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift`
+
+### Change
+
+**Line 60**, change:
+```swift
+if expectedCurrent != nil && expectedProgress > progress {
+```
+
+To:
+```swift
+if expectedCurrent != nil && isBehindTarget {
+```
+
+## Verification
+
+1. Build iOS app in Xcode
+2. Test with SwiftUI previews - verify "On Track" preview shows no orange
+3. Test on device/simulator with small deficits (< 25ml) - should show no orange
+4. Test with deficits >= 25ml (rounds to 50) - should show orange overlay and text together

--- a/ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift
+++ b/ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift
@@ -57,7 +57,8 @@ struct HumanFigureProgressView: View {
         VStack(spacing: 16) {
             ZStack {
                 // Expected progress fill (urgency color, behind actual)
-                if expectedCurrent != nil && expectedProgress > progress {
+                // Only show when isBehindTarget (50ml rounded threshold) for consistency with text
+                if expectedCurrent != nil && isBehindTarget {
                     GeometryReader { geometry in
                         VStack {
                             Spacer()


### PR DESCRIPTION
## Summary
- Fixed orange overlay appearing in human figure when user is "on track" with small deficit
- Changed overlay condition from exact float comparison to use `isBehindTarget` (50ml rounded threshold)
- Ensures visual overlay and "behind target" text appear/disappear together

## Details
See [Plan 043](Plans/043-orange-line-rounding-fix.md) for full analysis.

**Root cause:** The overlay used `expectedProgress > progress` (any deficit shows orange) while the text used `roundedDeficitMl >= 50` (50ml threshold). Small deficits (1-24ml) triggered the overlay but rounded to 0ml for text.

## Test plan
- [x] SwiftUI preview "On Track" shows no orange overlay
- [x] Small deficits (< 25ml) show no orange line
- [x] Deficits >= 25ml (rounds to 50) show both overlay and text together

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)