### PR TITLE
Add Retry button to "Bottle is Asleep" alert (Issue #52)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -22,6 +22,11 @@ Resume from PROGRESS.md.
 
 ## Recently Completed
 
+- ✅ Retry Button on "Bottle is Asleep" Alert (Issue #52) - [Plan 045](Plans/045-retry-bottle-asleep-alert.md)
+  - Added Retry/Cancel buttons to alert in HomeView and HistoryView
+  - Users can tap Retry after waking bottle instead of pulling down again
+  - Updated iOS-UX-PRD.md Section 2.4
+
 - ✅ Three-Color Stacked Human Figure Fill (Issue #50) - [Plan 044](Plans/044-three-color-stacked-fill.md)
   - Human figure now shows stacked blue/orange/red based on deficit thresholds
   - Orange: deficit up to 20% threshold

--- a/Plans/045-retry-bottle-asleep-alert.md
+++ b/Plans/045-retry-bottle-asleep-alert.md
@@ -1,0 +1,58 @@
+# Plan 045: Add Retry Button to "Bottle is Asleep" Alert
+
+**GitHub Issue:** #52
+**Branch:** `retry-bottle-asleep-alert`
+
+## Summary
+
+Add a Retry button to the "Bottle is Asleep" alert so users can immediately retry the connection after waking the bottle, instead of manually pulling down to refresh.
+
+## Current Behavior
+
+Both HomeView and HistoryView show an alert with only an "OK" button:
+```swift
+.alert("Bottle is Asleep", isPresented: $showBottleAsleepAlert) {
+    Button("OK", role: .cancel) { }
+} message: {
+    Text("Tilt your bottle to wake it up, then pull down to try again.")
+}
+```
+
+## Implementation
+
+### Files to Modify
+
+1. `ios/Aquavate/Aquavate/Views/HomeView.swift` (~line 308)
+2. `ios/Aquavate/Aquavate/Views/HistoryView.swift` (~line 184)
+
+### Changes
+
+Update the alert in both files to:
+
+```swift
+.alert("Bottle is Asleep", isPresented: $showBottleAsleepAlert) {
+    Button("Retry") {
+        Task {
+            await handleRefresh()
+        }
+    }
+    Button("Cancel", role: .cancel) { }
+} message: {
+    Text("Tilt your bottle to wake it up, then tap Retry.")
+}
+```
+
+**Key points:**
+- Retry button triggers `handleRefresh()` wrapped in a Task (async context)
+- Cancel button has `role: .cancel` for standard dismissal styling
+- Message updated: "pull down to try again" → "tap Retry"
+- Retry button listed first (appears on right/primary position on iOS)
+
+## Verification
+
+1. Build the app in Xcode
+2. With bottle asleep (not advertising), pull down to refresh on HomeView
+3. Alert should appear with "Retry" and "Cancel" buttons
+4. Tap Cancel → alert dismisses, no action
+5. Pull down again, tap Retry → new connection attempt begins
+6. Repeat test on HistoryView

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -1,10 +1,11 @@
 # Aquavate iOS App - UX Product Requirements Document
 
-**Version:** 1.11
+**Version:** 1.12
 **Date:** 2026-01-24
-**Status:** Approved and Tested (Three-Color Stacked Fill)
+**Status:** Approved and Tested (Retry Bottle Asleep Alert)
 
 **Changelog:**
+- **v1.12 (2026-01-24):** Added Retry/Cancel buttons to "Bottle is Asleep" alert (Issue #52). Users can now tap Retry after waking bottle instead of manually pulling down again. See Section 2.4.
 - **v1.11 (2026-01-24):** Three-color stacked fill for human figure (Issue #50). When behind target, shows orange for deficit up to 20%, red for deficit beyond 20%. See Section 2.9.
 - **v1.10 (2026-01-24):** Activity Stats now persist in CoreData (Issue #36 Comment). Users can view cached data when disconnected with "Last synced X ago" timestamp. Diagnostics section accessible when disconnected.
 - **v1.9 (2026-01-24):** Added Hydration Reminders with pace-based urgency model (Issue #27). Added Apple Watch companion app with complications. Added target intake visualization on HomeView. See Section 2.8 (Watch App) and Section 7 (Notification Strategy).
@@ -337,7 +338,8 @@ Sarah's Bluetooth is accidentally turned off. When she opens the app, she sees a
 
 **Pull-to-Refresh Alerts:**
 - "Bottle is Asleep" alert if scan times out (~10s) with no devices found
-  - Message: "Tilt your bottle to wake it up, then pull down to try again."
+  - Message: "Tilt your bottle to wake it up, then tap Retry."
+  - Buttons: **Retry** (triggers new connection attempt) | **Cancel** (dismisses alert)
 - "Sync Error" alert if connection fails or sync interrupted
 - "Bluetooth is turned off" error if Bluetooth unavailable
 

--- a/ios/Aquavate/Aquavate/Views/HistoryView.swift
+++ b/ios/Aquavate/Aquavate/Views/HistoryView.swift
@@ -182,9 +182,14 @@ struct HistoryView: View {
                 Text("Please connect to your bottle before deleting drinks. This ensures both the app and bottle stay in sync.")
             }
             .alert("Bottle is Asleep", isPresented: $showBottleAsleepAlert) {
-                Button("OK", role: .cancel) { }
+                Button("Retry") {
+                    Task {
+                        await handleRefresh()
+                    }
+                }
+                Button("Cancel", role: .cancel) { }
             } message: {
-                Text("Tilt your bottle to wake it up, then pull down to try again.")
+                Text("Tilt your bottle to wake it up, then tap Retry.")
             }
             .alert("Sync Error", isPresented: $showErrorAlert) {
                 Button("OK", role: .cancel) { }

--- a/ios/Aquavate/Aquavate/Views/HomeView.swift
+++ b/ios/Aquavate/Aquavate/Views/HomeView.swift
@@ -306,9 +306,14 @@ struct HomeView: View {
             }
         }
         .alert("Bottle is Asleep", isPresented: $showBottleAsleepAlert) {
-            Button("OK", role: .cancel) { }
+            Button("Retry") {
+                Task {
+                    await handleRefresh()
+                }
+            }
+            Button("Cancel", role: .cancel) { }
         } message: {
-            Text("Tilt your bottle to wake it up, then pull down to try again.")
+            Text("Tilt your bottle to wake it up, then tap Retry.")
         }
         .alert("Sync Error", isPresented: $showErrorAlert) {
             Button("OK", role: .cancel) { }


### PR DESCRIPTION
## Summary

- Added Retry/Cancel buttons to "Bottle is Asleep" alert
- Users can tap Retry after waking bottle instead of manually pulling down again
- Updated alert message: "Tilt your bottle to wake it up, then tap Retry."

## Changes

- **HomeView.swift**: Updated alert with Retry button that calls `handleRefresh()`
- **HistoryView.swift**: Same change for consistency
- **iOS-UX-PRD.md**: Updated Section 2.4 to document new behavior (v1.12)

## Test Plan

- [x] Built and ran in Xcode
- [x] Verified alert shows Retry and Cancel buttons
- [x] Verified Cancel dismisses alert
- [x] Verified Retry triggers new connection attempt

See [Plan 045](Plans/045-retry-bottle-asleep-alert.md) for full details.

Closes #52