### PR TITLE
Show last known bottle level with (recent) indicator (Issue #57)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,7 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-01-24
-**Current Branch:** `master`
+**Last Updated:** 2026-01-25
+**Current Branch:** `bottle-level-recent-indicator`
 
 ---
 
@@ -21,6 +21,12 @@ Resume from PROGRESS.md.
 ---
 
 ## Recently Completed
+
+- ✅ Bottle Level Recent Indicator (Issue #57) - [Plan 047](Plans/047-bottle-level-recent-indicator.md)
+  - Shows last known bottle level with "(recent)" suffix when disconnected
+  - Hides bottle level section entirely until first connection
+  - Persists `bottleLevelMl` and `hasReceivedBottleData` to UserDefaults
+  - Updated IOS-UX-PRD.md Section 2.4
 
 - ✅ Daily Rollover Timer Wake - [Plan 046](Plans/046-daily-rollover-timer-wake.md)
   - Wake bottle at 4am daily rollover to refresh display with reset daily total

--- a/Plans/047-bottle-level-recent-indicator.md
+++ b/Plans/047-bottle-level-recent-indicator.md
@@ -1,0 +1,86 @@
+# Plan: Issue #57 - Show Last Known Bottle Level with "(recent)" Indicator
+
+## Problem Summary
+
+When the bottle is disconnected, the bottle level shows 0% because:
+- `bottleLevelMl` is initialized to 0 in BLEManager
+- Unlike `dailyGoalMl`, bottle level is not persisted to UserDefaults
+- When the app restarts or loses connection, the in-memory value resets
+
+## Implementation Approach
+
+### 1. Persist Bottle Level to UserDefaults (BLEManager.swift)
+
+Add persistence for `bottleLevelMl` similar to the existing `dailyGoalMl` pattern:
+
+**File:** [BLEManager.swift](ios/Aquavate/Aquavate/Services/BLEManager.swift)
+
+```swift
+// Line ~102 - Add didSet to persist
+@Published private(set) var bottleLevelMl: Int = 0 {
+    didSet {
+        UserDefaults.standard.set(bottleLevelMl, forKey: "lastKnownBottleLevelMl")
+    }
+}
+
+// Add a new published property to track if we've ever received bottle data
+@Published private(set) var hasReceivedBottleData: Bool = false {
+    didSet {
+        UserDefaults.standard.set(hasReceivedBottleData, forKey: "hasReceivedBottleData")
+    }
+}
+```
+
+In `init()`, restore from UserDefaults:
+```swift
+bottleLevelMl = UserDefaults.standard.integer(forKey: "lastKnownBottleLevelMl")
+hasReceivedBottleData = UserDefaults.standard.bool(forKey: "hasReceivedBottleData")
+```
+
+In `handleCurrentStateUpdate()` (line ~1046), set the flag when we receive data:
+```swift
+bottleLevelMl = Int(state.bottleLevelMl)
+hasReceivedBottleData = true  // Add this line
+```
+
+### 2. Update Bottle Level Display (HomeView.swift)
+
+**File:** [HomeView.swift](ios/Aquavate/Aquavate/Views/HomeView.swift)
+
+Modify the bottle level section (lines 238-261) to:
+- Show "(recent)" suffix when disconnected but have previous data
+- Hide the entire section if no connection has ever happened
+
+```swift
+// Add computed property
+private var bottleLevelSuffix: String {
+    if bleManager.connectionState.isConnected {
+        return ""
+    } else if bleManager.hasReceivedBottleData {
+        return " (recent)"
+    }
+    return ""
+}
+
+// Wrap bottle level section in conditional
+if bleManager.hasReceivedBottleData || bleManager.connectionState.isConnected {
+    // Existing VStack for "Bottle Level"
+    // Modify the percentage text to include suffix:
+    Text("\(Int(bottleProgress * 100))%\(bottleLevelSuffix)")
+}
+```
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| [BLEManager.swift](ios/Aquavate/Aquavate/Services/BLEManager.swift) | Add persistence for `bottleLevelMl`, add `hasReceivedBottleData` flag |
+| [HomeView.swift](ios/Aquavate/Aquavate/Views/HomeView.swift) | Conditionally show bottle level section, add "(recent)" suffix |
+
+## Verification
+
+1. **Fresh install scenario**: Launch app without ever connecting - bottle level section should not be visible
+2. **Connect and disconnect**: Connect to bottle, note level, disconnect - should show "75% (recent)"
+3. **Reconnect**: Connect again - "(recent)" suffix should disappear
+4. **App restart**: Close app while disconnected, reopen - should still show last known level with "(recent)"
+5. **Build verification**: Run `platformio run` to ensure firmware still builds (no firmware changes needed)

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -1,10 +1,11 @@
 # Aquavate iOS App - UX Product Requirements Document
 
-**Version:** 1.12
-**Date:** 2026-01-24
-**Status:** Approved and Tested (Retry Bottle Asleep Alert)
+**Version:** 1.13
+**Date:** 2026-01-25
+**Status:** Approved and Tested (Bottle Level Recent Indicator)
 
 **Changelog:**
+- **v1.13 (2026-01-25):** Bottle level now shows last known value with "(recent)" indicator when disconnected (Issue #57). Section is hidden until first connection. See Section 2.4.
 - **v1.12 (2026-01-24):** Added Retry/Cancel buttons to "Bottle is Asleep" alert (Issue #52). Users can now tap Retry after waking bottle instead of manually pulling down again. See Section 2.4.
 - **v1.11 (2026-01-24):** Three-color stacked fill for human figure (Issue #50). When behind target, shows orange for deficit up to 20%, red for deficit beyond 20%. See Section 2.9.
 - **v1.10 (2026-01-24):** Activity Stats now persist in CoreData (Issue #36 Comment). Users can view cached data when disconnected with "Last synced X ago" timestamp. Diagnostics section accessible when disconnected.
@@ -322,10 +323,17 @@ Sarah's Bluetooth is accidentally turned off. When she opens the app, she sees a
 | Element | Source | Format |
 |---------|--------|--------|
 | Daily total (PRIMARY) | CoreData sum (always) | "{X} ml of {goal}ml goal" |
-| Bottle level (SECONDARY) | BLE Current State (real-time) | "{X}ml / {capacity}ml" |
+| Bottle level (SECONDARY) | BLE Current State (persisted) | "{X}ml / {capacity}ml" + optional "(recent)" |
 | Today's drinks | CoreData (ALL today's drinks) | Amount (bold), time, level after |
 | Sync status | Last BLE sync timestamp | "Last synced {X} ago" |
 | Connection dot | BLE connection state | Green/Orange/Gray |
+
+**Bottle Level Display States (Added 2026-01-25):**
+| State | Display |
+|-------|---------|
+| Never connected | Section hidden entirely |
+| Connected | Shows live value (e.g., "56%") |
+| Disconnected with previous data | Shows last known value with "(recent)" suffix (e.g., "56% (recent)") |
 
 **Pull-to-Refresh (Updated 2026-01-18):**
 - If disconnected: Scans and connects to bottle, syncs, stays connected 60s

--- a/ios/Aquavate/Aquavate/Views/HomeView.swift
+++ b/ios/Aquavate/Aquavate/Views/HomeView.swift
@@ -69,6 +69,16 @@ struct HomeView: View {
         return min(1.0, Double(displayBottleLevel) / Double(displayCapacity))
     }
 
+    /// Suffix to show when bottle level is from a previous session
+    private var bottleLevelSuffix: String {
+        if bleManager.connectionState.isConnected {
+            return ""
+        } else if bleManager.hasReceivedBottleData {
+            return " (recent)"
+        }
+        return ""
+    }
+
     // Delete today's drinks at given offsets - requires bottle connection for bidirectional sync
     private func deleteTodaysDrinks(at offsets: IndexSet) {
         // Require bottle connection for deletion
@@ -235,31 +245,34 @@ struct HomeView: View {
                     urgency: hydrationReminderService.currentUrgency
                 )
 
-                // Bottle level progress bar (SECONDARY)
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Text("Bottle Level")
-                            .font(.headline)
-                        Spacer()
-                        Text("\(Int(bottleProgress * 100))%")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
+                // Bottle level progress bar (SECONDARY) - only show if we have data
+                if bleManager.hasReceivedBottleData || bleManager.connectionState.isConnected {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Bottle Level")
+                                .font(.headline)
+                            Spacer()
+                            Text("\(Int(bottleProgress * 100))%\(bottleLevelSuffix)")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
 
-                    ProgressView(value: bottleProgress)
-                        .tint(.blue)
+                        ProgressView(value: bottleProgress)
+                            .tint(.blue)
 
-                    HStack {
-                        Text("\(displayBottleLevel)ml")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                        Text("/ \(displayCapacity)ml")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                        HStack {
+                            Text("\(displayBottleLevel)ml")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            Text("/ \(displayCapacity)ml")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
                     }
+                    .padding(.horizontal)
                 }
-                .padding(.horizontal)
             }
+            .frame(maxWidth: .infinity)
             .padding(.vertical, 8)
             .background(Color(.systemGroupedBackground))
 


### PR DESCRIPTION
## Summary

- When disconnected, bottle level now shows last known value with "(recent)" suffix instead of 0%
- Bottle level section is hidden entirely until first connection (avoids showing stale 0%)
- Persists `bottleLevelMl` and `hasReceivedBottleData` to UserDefaults for app restart

Closes #57

## Implementation Details

See [Plan 047](Plans/047-bottle-level-recent-indicator.md) for full implementation details.

**Files changed:**
- `BLEManager.swift` - Added persistence for bottle level and connection history flag
- `HomeView.swift` - Added conditional display and "(recent)" suffix

## Test Plan

- [x] Fresh install: Bottle level section hidden (no data yet)
- [x] Connect then disconnect: Shows "XX% (recent)" 
- [x] Reconnect: "(recent)" suffix disappears
- [x] App restart while disconnected: Shows persisted level with "(recent)"
- [x] Background color consistent (grey) when bottle level hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)