### PR TITLE
Fix human figure not filling completely at 100% (Issue #59)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,7 @@
 # Aquavate - Active Development Progress
 
 **Last Updated:** 2026-01-25
-**Current Branch:** `bottle-level-recent-indicator`
+**Current Branch:** `master`
 
 ---
 
@@ -21,6 +21,11 @@ Resume from PROGRESS.md.
 ---
 
 ## Recently Completed
+
+- ✅ Human Figure Fill Fix (Issue #59) - [Plan 048](Plans/048-human-figure-fill-fix.md)
+  - Fixed white gap at top of head when goal reached/exceeded
+  - SwiftUI `Spacer()` default minLength caused fill to not reach 100%
+  - Changed to `Spacer(minLength: 0)` in HumanFigureProgressView.swift
 
 - ✅ Bottle Level Recent Indicator (Issue #57) - [Plan 047](Plans/047-bottle-level-recent-indicator.md)
   - Shows last known bottle level with "(recent)" suffix when disconnected

--- a/Plans/048-human-figure-fill-fix.md
+++ b/Plans/048-human-figure-fill-fix.md
@@ -1,0 +1,14 @@
+# Fix: Human Figure Not Completely Filled (Issue #59)
+
+## Problem
+White gap at top of head when goal reached/exceeded in iOS app.
+
+## Root Cause
+`Spacer()` in SwiftUI has default minimum length (~8pt). At 100% fill, the spacer still takes space.
+
+## Fix
+Change `Spacer()` to `Spacer(minLength: 0)` at lines 74, 95, and 111 in:
+- [ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift](ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift)
+
+## Verification
+Build iOS app, exceed daily goal, confirm head fills completely.

--- a/ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift
+++ b/ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift
@@ -72,7 +72,7 @@ struct HumanFigureProgressView: View {
                 if expectedCurrent != nil && isBehindTarget && isOverdue {
                     GeometryReader { geometry in
                         VStack {
-                            Spacer()
+                            Spacer(minLength: 0)
                             Rectangle()
                                 .fill(Color.red.opacity(0.3))
                                 .frame(height: geometry.size.height * expectedProgress)
@@ -91,7 +91,7 @@ struct HumanFigureProgressView: View {
                 if expectedCurrent != nil && isBehindTarget {
                     GeometryReader { geometry in
                         VStack {
-                            Spacer()
+                            Spacer(minLength: 0)
                             Rectangle()
                                 .fill(Color.orange.opacity(0.3))
                                 .frame(height: geometry.size.height * orangeTopProgress)
@@ -108,7 +108,7 @@ struct HumanFigureProgressView: View {
                 // Actual progress fill from bottom using filled silhouette as mask
                 GeometryReader { geometry in
                     VStack {
-                        Spacer()
+                        Spacer(minLength: 0)
                         Rectangle()
                             .fill(color)
                             .frame(height: geometry.size.height * progress)


### PR DESCRIPTION
## Summary
- Fixed white gap at top of head when daily goal reached/exceeded in iOS app
- Root cause: SwiftUI `Spacer()` has default minimum length (~8pt)
- Solution: Changed to `Spacer(minLength: 0)` in all three fill rectangles

See [Plan 048](Plans/048-human-figure-fill-fix.md) for details.

## Test plan
- [x] Build iOS app
- [x] Set daily intake to exceed goal (e.g., 2677ml / 2500ml)
- [x] Verify human figure head fills completely with no white gap

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)