### PR TITLE
Change daily rollover from 4am to midnight (Issue #47)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -22,6 +22,11 @@ Resume from PROGRESS.md.
 
 ## Recently Completed
 
+- ✅ Midnight Rollover for HealthKit Alignment (Issue #47) - [Plan 049](Plans/049-midnight-rollover.md)
+  - Changed daily reset from 4am to midnight to align with Apple Health
+  - Updated firmware config.h and iOS BLEConstants.swift
+  - Updated PRD.md and IOS-UX-PRD.md documentation
+
 - ✅ Human Figure Fill Fix (Issue #59) - [Plan 048](Plans/048-human-figure-fill-fix.md)
   - Fixed white gap at top of head when goal reached/exceeded
   - SwiftUI `Spacer()` default minLength caused fill to not reach 100%

--- a/Plans/049-midnight-rollover.md
+++ b/Plans/049-midnight-rollover.md
@@ -1,0 +1,51 @@
+# Plan: Change Daily Rollover to Midnight (Issue #47)
+
+## Summary
+
+Change the daily rollover time from 4am to midnight (0) to align with HealthKit's day boundaries. This is a simple constant change in 2 files.
+
+## Background
+
+The original 4am boundary was chosen to handle late-night drinking (drinks at 1am count as "yesterday"). However, this causes confusion when comparing Aquavate totals with Apple Health, which uses midnight. HealthKit alignment is more valuable for most users than the late-night edge case.
+
+---
+
+## Implementation
+
+### Firmware
+
+**[firmware/src/config.h](firmware/src/config.h)** line 240:
+```cpp
+#define DRINK_DAILY_RESET_HOUR    0    // Reset at midnight (was 4)
+```
+
+### iOS App
+
+**[ios/Aquavate/Aquavate/Services/BLEConstants.swift](ios/Aquavate/Aquavate/Services/BLEConstants.swift)** line 149:
+```swift
+static let dailyResetHour = 0    // Midnight (was 4)
+```
+
+Also update the documentation comments in the Calendar extension (lines 152-159) to reflect midnight instead of 4am.
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| [firmware/src/config.h](firmware/src/config.h) | Change `DRINK_DAILY_RESET_HOUR` from `4` to `0` |
+| [ios/.../BLEConstants.swift](ios/Aquavate/Aquavate/Services/BLEConstants.swift) | Change `dailyResetHour` from `4` to `0`, update comments |
+
+---
+
+## Verification
+
+1. **Build firmware**: `cd firmware && ~/.platformio/penv/bin/platformio run`
+2. **Build iOS app**: Open Xcode, build and run on device
+3. **Test**:
+   - Verify drinks at 11pm count as "today"
+   - Verify drinks at 12:30am count as "tomorrow" (the new day)
+   - Verify daily total resets at midnight
+   - Verify bottle timer wake happens at midnight (not 4am)
+   - Compare with Apple Health - totals should now align

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -143,8 +143,8 @@ After cutting, verify LED no longer illuminates when board is powered.
 
 #### Wake Triggers
 - **Motion wake:** LIS3DH interrupt on motion (>300mg threshold) via GPIO 27
-- **Rollover wake:** Timer-based wake at 4am daily reset to refresh display with 0ml daily total
-  - Ensures display shows correct daily total even if bottle sleeps through midnight
+- **Rollover wake:** Timer-based wake at midnight daily reset to refresh display with 0ml daily total
+  - Ensures display shows correct daily total even if bottle sleeps through rollover
   - Returns to sleep immediately after display refresh (no BLE advertising)
 
 #### Stability Detection (Both Combined)
@@ -377,16 +377,9 @@ For detailed screen specifications, layouts, and UX flows, see [iOS-UX-PRD.md](i
 - Store HealthKit sample UUID for deletion support
 - Request HealthKit authorization from Settings (opt-in)
 
-#### Day Boundary Difference
+#### Day Boundary Alignment
 
-**Important:** Aquavate uses a **4am daily reset boundary** while Apple HealthKit uses **midnight-to-midnight** days.
-
-| System | Day Boundary | Example: 2am drink |
-|--------|--------------|-------------------|
-| Aquavate (bottle + app) | 4:00 AM | Counts as "yesterday" |
-| Apple Health | 12:00 AM (midnight) | Counts as "today" |
-
-This means daily totals may differ slightly for drinks taken between midnight and 4am. Individual drink timestamps are preserved correctly in HealthKit. This design prioritizes user experience (late-night drinks feel like "yesterday") over strict calendar alignment.
+Aquavate uses **midnight** as the daily reset boundary, matching Apple HealthKit's day boundaries. Daily totals in Aquavate and Apple Health will align correctly.
 
 ### 6. Notifications
 

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -13,7 +13,7 @@
 - **v1.8 (2026-01-23):** Added Diagnostics section to Settings with Activity Stats view (Issue #36). Shows motion wake events and backpack sessions for battery analysis. Includes "drink taken" indicator (water drop icon) for wakes where user took a drink.
 - **v1.7 (2026-01-23):** Added Gestures section to Settings with Shake-to-Empty toggle. Setting syncs to firmware via BLE Device Settings characteristic.
 - **v1.6 (2026-01-22):** Settings page cleanup - replaced static "Name" with live "Device" showing connected device name, removed unused "Use Ounces" toggle, removed Version row from About section.
-- **v1.5 (2026-01-21):** Added Apple HealthKit integration (Section 2.7). Drinks sync to Health app as water intake samples. Added day boundary documentation (4am vs midnight).
+- **v1.5 (2026-01-21):** Added Apple HealthKit integration (Section 2.7). Drinks sync to Health app as water intake samples.
 - **v1.4 (2026-01-21):** Bidirectional drink record sync. Swipe-to-delete now requires bottle connection and uses pessimistic delete with firmware confirmation. HomeView shows ALL today's drinks (not just recent 5).
 - **v1.3 (2026-01-20):** Added swipe-to-delete for drink records (Section 4 Gestures). Updated Reset Daily to also clear today's CoreData records.
 - **v1.2 (2026-01-18):** Added Pull-to-Refresh sync for Home screen (Section 2.4). Connection stays open 60s for real-time updates. Settings connection controls wrapped in `#if DEBUG` (Section 2.6).
@@ -563,10 +563,7 @@ If `time_valid` flag is false:
 - HealthKit sample UUID stored for deletion support
 
 **Day Boundary Note:**
-Aquavate uses a **4am daily reset** while Apple Health uses **midnight**. This means:
-- A drink at 2am shows as "yesterday" in Aquavate but "today" in Health app
-- Individual drink timestamps are accurate in both systems
-- Only daily totals may differ for late-night drinks (midnight-4am)
+Aquavate uses **midnight** as the daily reset, matching Apple Health. Daily totals align between both systems.
 
 ---
 
@@ -1820,7 +1817,7 @@ This UX PRD defines the complete user experience for the Aquavate iOS app. Upon 
 - Apple HealthKit integration implemented (Settings toggle, auto-sync)
 - Each drink creates a water intake sample in Health app
 - Deleting drinks removes corresponding HealthKit samples
-- Day boundary difference documented (4am vs midnight)
+- Day boundary now uses midnight (aligns with HealthKit)
 
 **Update Note (2026-01-21 - Bidirectional Sync):**
 - Bidirectional drink record sync implemented

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -237,7 +237,7 @@ extern uint8_t g_daily_intake_display_mode;
 // Drink detection parameters
 #define DRINK_MIN_THRESHOLD_ML          30      // Minimum ml decrease to detect a drink
 #define DRINK_REFILL_THRESHOLD_ML       100     // Minimum ml increase to detect a refill
-#define DRINK_DAILY_RESET_HOUR          4       // Reset daily counter at 4am local time
+#define DRINK_DAILY_RESET_HOUR          0       // Reset daily counter at midnight (aligns with HealthKit)
 #define DRINK_DISPLAY_UPDATE_THRESHOLD_ML 50    // Only refresh display if daily total changed by ≥50ml
 #define DRINK_MAX_RECORDS               600     // Circular buffer capacity (30 days at 20 drinks/day)
 #define DRINK_DAILY_GOAL_ML             2500    // Hardcoded daily goal for MVP


### PR DESCRIPTION
## Summary

Changes the daily rollover time from 4am to midnight to align with Apple HealthKit's day boundaries.

See [Plan 049](Plans/049-midnight-rollover.md) for full details.

## Changes

- **Firmware**: `DRINK_DAILY_RESET_HOUR` changed from `4` to `0` in config.h
- **iOS**: `dailyResetHour` changed from `4` to `0` in BLEConstants.swift
- **Docs**: Updated PRD.md and IOS-UX-PRD.md to reflect midnight boundary

## Testing

- ✅ Firmware build successful
- ⏳ iOS app build (user to verify in Xcode)
- ⏳ Manual verification scenarios:
  - Drinks at 11pm count as "today"
  - Drinks at 12:30am count as "tomorrow" (new day)
  - Daily total resets at midnight
  - Bottle timer wake at midnight
  - Daily totals align with Apple Health

Closes #47

🤖 Generated with [Claude Code](https://claude.ai/code)