### PR TITLE
Add single-tap wake for normal sleep mode (Issue #63)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ pio device monitor         # Serial monitor
 ```
 
 **Important Implementation Details:**
-- LIS3DH INT1 pin must be wired to ESP32 GPIO 27 (not just I2C)
-- LIS3DH needs always-on 3V power (not STEMMA QT which powers down)
+- ADXL343 INT1 pin must be wired to ESP32 GPIO 27 (not just I2C)
+- ADXL343 needs always-on 3V power (not STEMMA QT which powers down)
 - Wake-on-tilt threshold: 0.80g (0x32)
 - Deep sleep: Dual modes (normal 30s with motion wake, extended 60s with timer wake)
 - RTC memory: Used for display state and drink baseline persistence across sleep
@@ -111,7 +111,7 @@ The firmware supports comprehensive serial commands for configuration and testin
 
 **Debug Control:**
 - `0-4`, `9` - Set debug level (0=OFF, 1=Events, 2=+Gestures, 3=+Weight, 4=+Accel, 9=All)
-- `T` - Test interrupt state (shows LIS3DH INT1_SRC register)
+- `T` - Test interrupt state (shows ADXL343 INT_SOURCE register)
 
 **Time/Timezone:**
 - `SET DATETIME YYYY-MM-DD HH:MM:SS [tz]` - Set date, time, and timezone
@@ -147,7 +147,7 @@ The firmware supports comprehensive serial commands for configuration and testin
 - Good for testing build system and code structure
 
 ### With Hardware
-- Check sensor I2C addresses: NAU7802 (0x2A), LIS3DH (0x18)
+- Check sensor I2C addresses: NAU7802 (0x2A), ADXL343 (0x53)
 - Verify load cell wiring: Red (E+), Black (E-), White (A-), Green (A+)
 - Test wake-on-tilt by tilting board
 - Monitor deep sleep current with multimeter (target <200µA)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Two prototype configurations are being evaluated:
 - Adafruit ESP32 Feather V2 (STEMMA QT)
 - 2.13" Mono E-Paper FeatherWing (stacks directly - no wiring)
 - NAU7802 24-bit ADC for load cell
-- LIS3DH accelerometer for wake-on-tilt
+- ADXL343 accelerometer for wake-on-tilt
 - UK BOM: [Plans/002-bom-adafruit-feather.md](Plans/002-bom-adafruit-feather.md)
 
 ### Option B: SparkFun Qwiic Ecosystem
@@ -37,7 +37,7 @@ Two prototype configurations are being evaluated:
 - **Libraries Integrated:**
   - Adafruit EPD (ThinkInk) - 2.13" e-paper display ✅
   - Adafruit NAU7802 - Load cell ADC ✅
-  - Adafruit LIS3DH - Accelerometer with wake interrupt ✅
+  - Adafruit ADXL343 - Accelerometer with wake interrupt ✅
   - NimBLE-Arduino - BLE communication (planned)
 
 ### iOS App - Skeleton Created

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -22,6 +22,13 @@ Resume from PROGRESS.md. Ready for next task.
 
 ## Recently Completed
 
+- ✅ Single-Tap Wake for Normal Sleep (Issue #63) - [Plan 050](Plans/050-single-tap-wake.md)
+  - Added single-tap detection alongside motion wake for normal sleep mode
+  - INT_ENABLE changed from 0x10 (activity only) to 0x50 (activity + single-tap)
+  - Tap threshold: 3.0g (same as backpack mode double-tap)
+  - Updated iOS "Bottle is Asleep" alert: "Tap or tilt your bottle to wake it up"
+  - Fixed LIS3DH → ADXL343 references in documentation
+
 - ✅ Enhanced Backpack Mode with Tap-to-Wake (Issue #38) - [Plan 039](Plans/039-enhanced-backpack-mode-display.md)
   - Backpack mode screen shows "backpack mode" with "double-tap firmly to wake up" instructions
   - RTC flag prevents redundant display refreshes on re-entry
@@ -39,26 +46,6 @@ Resume from PROGRESS.md. Ready for next task.
   - Fixed white gap at top of head when goal reached/exceeded
   - SwiftUI `Spacer()` default minLength caused fill to not reach 100%
   - Changed to `Spacer(minLength: 0)` in HumanFigureProgressView.swift
-
-- ✅ Bottle Level Recent Indicator (Issue #57) - [Plan 047](Plans/047-bottle-level-recent-indicator.md)
-  - Shows last known bottle level with "(recent)" suffix when disconnected
-  - Hides bottle level section entirely until first connection
-  - Persists `bottleLevelMl` and `hasReceivedBottleData` to UserDefaults
-  - Updated IOS-UX-PRD.md Section 2.4
-
-- ✅ Daily Rollover Timer Wake - [Plan 046](Plans/046-daily-rollover-timer-wake.md)
-  - Wake bottle at midnight daily rollover to refresh display with reset daily total
-  - ESP32 timer wake source alongside motion wake (wakes on first to trigger)
-  - Returns to sleep immediately after display refresh (no BLE advertising)
-  - Updated PRD.md Section 2 Wake Triggers
-
----
-
-## Known Issues
-
-**Wake-on-tilt sensitivity (ADXL343):**
-- Requires deliberate shake (~2 seconds) due to aggressive filtering
-- Trade-off accepted for battery life benefits
 
 ---
 

--- a/Plans/050-single-tap-wake.md
+++ b/Plans/050-single-tap-wake.md
@@ -1,0 +1,95 @@
+# Plan: Add Single-Tap Wake to Normal Sleep Mode
+
+**Issue**: #63
+
+## Summary
+Add single-tap detection as an additional wake source for normal deep sleep mode, alongside the existing sustained motion detection. Also fix documentation that incorrectly references LIS3DH accelerometer (should be ADXL343).
+
+## Current Behavior
+- **Normal sleep**: Wakes on sustained motion (>3.0g for >1.6 seconds) - requires deliberate shake
+- **Extended sleep (backpack)**: Wakes on double-tap only
+
+## Proposed Behavior
+- **Normal sleep**: Wakes on single-tap OR sustained motion (either triggers wake)
+- **Extended sleep (backpack)**: Unchanged (double-tap only)
+
+## Implementation
+
+### 1. Modify `configureADXL343Interrupt()` in [main.cpp](firmware/src/main.cpp)
+
+Add tap detection configuration alongside existing activity detection:
+
+```cpp
+// Add tap registers (after existing activity config)
+const uint8_t THRESH_TAP = 0x1D;
+const uint8_t DUR = 0x21;
+const uint8_t TAP_AXES = 0x2A;
+
+// Configure tap threshold (same as double-tap: 3.0g)
+writeAccelReg(THRESH_TAP, TAP_WAKE_THRESHOLD);  // 0x30 = 3.0g
+
+// Configure tap duration (10ms max)
+writeAccelReg(DUR, TAP_WAKE_DURATION);  // 0x10 = 10ms
+
+// Enable all axes for tap detection
+writeAccelReg(TAP_AXES, 0x07);  // X, Y, Z
+
+// Change INT_ENABLE from 0x10 to 0x50
+// Bit 4 = Activity (0x10)
+// Bit 6 = Single-tap (0x40)
+// Combined = 0x50
+writeAccelReg(INT_ENABLE, 0x50);
+```
+
+**Key change**: Line 267 changes from `0x10` (activity only) to `0x50` (activity + single-tap).
+
+### 2. Update Serial Output Messages
+
+Update the configuration complete message to reflect both wake methods:
+```
+"Wake condition: Single-tap OR sustained motion (>3.0g)"
+```
+
+### 3. Documentation Updates (LIS3DH → ADXL343)
+
+Files requiring updates (19 files found):
+
+**Critical files:**
+- [CLAUDE.md](CLAUDE.md) - Lines mentioning "LIS3DH accelerometer"
+- [AGENTS.md](AGENTS.md)
+- [README.md](README.md)
+- [docs/PRD.md](docs/PRD.md)
+
+**Pin config comments:**
+- [firmware/src/config/pins_adafruit.h](firmware/src/config/pins_adafruit.h)
+- [firmware/src/config/pins_sparkfun.h](firmware/src/config/pins_sparkfun.h) - Line 30 says "LIS3DH"
+
+**Plan documents:**
+- [Plans/001-hardware-research.md](Plans/001-hardware-research.md)
+- [Plans/002-bom-adafruit-feather.md](Plans/002-bom-adafruit-feather.md)
+- [Plans/003-bom-sparkfun-qwiic.md](Plans/003-bom-sparkfun-qwiic.md)
+- [Plans/004-sensor-puck-design.md](Plans/004-sensor-puck-design.md)
+- [Plans/005-standalone-calibration-mode.md](Plans/005-standalone-calibration-mode.md)
+- [Plans/007-daily-intake-tracking.md](Plans/007-daily-intake-tracking.md)
+- [Plans/010-deep-sleep-reinstatement.md](Plans/010-deep-sleep-reinstatement.md)
+- [Plans/011-extended-deep-sleep-backpack-mode.md](Plans/011-extended-deep-sleep-backpack-mode.md)
+- [Plans/022-ds3231-rtc-integration.md](Plans/022-ds3231-rtc-integration.md)
+- [Plans/023-adxl343-accelerometer-migration.md](Plans/023-adxl343-accelerometer-migration.md)
+- [docs/mechanical/component-dimensions.md](docs/mechanical/component-dimensions.md)
+- [docs/STATE_MACHINE.md](docs/STATE_MACHINE.md)
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| [firmware/src/main.cpp](firmware/src/main.cpp) | Add single-tap config to `configureADXL343Interrupt()` |
+| 19 documentation files | Replace "LIS3DH" with "ADXL343" |
+
+## Verification
+
+1. Build firmware: `cd firmware && ~/.platformio/penv/bin/platformio run`
+2. User uploads and tests:
+   - Place bottle upright, let it enter normal sleep
+   - Single tap should wake it
+   - Sustained shake should also wake it (existing behavior)
+   - Backpack mode should still require double-tap (unchanged)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Pin definitions are automatically selected based on these flags.
 
 ### Implemented
 - ✅ Weight-based water tracking via NAU7802 load cell ADC
-- ✅ Wake-on-tilt using LIS3DH accelerometer interrupt (0.80g threshold)
+- ✅ Wake-on-tilt using ADXL343 accelerometer interrupt (single-tap or motion)
 - ✅ E-paper display with battery status, time, and bottle graphic
 - ✅ Deep sleep with dual modes for 1-2 week battery life:
   - Normal sleep: 30s timeout with motion wake (EXT0 interrupt)

--- a/docs/STATE_MACHINE.md
+++ b/docs/STATE_MACHINE.md
@@ -80,20 +80,20 @@ The bottle operates in one of three primary modes:
 
 **What the bottle does:**
 - ESP32 enters deep sleep mode
-- All peripherals powered down except LIS3DH accelerometer
+- All peripherals powered down except ADXL343 accelerometer
 - Waits for tilt interrupt
 
 **How to enter:**
 - After timeout with no activity (feature disabled for development)
 
 **How to exit:**
-- LIS3DH detects tilt (Z-axis < threshold) → Wake → Normal Operation
+- ADXL343 detects tilt (Z-axis < threshold) → Wake → Normal Operation
 
 ---
 
 ## Bottle Orientations (Gestures)
 
-The firmware recognizes four bottle orientations using the LIS3DH accelerometer:
+The firmware recognizes four bottle orientations using the ADXL343 accelerometer:
 
 ### INVERTED_HOLD
 - **Detection:** Z-axis < -0.8g held for 5 seconds
@@ -324,7 +324,7 @@ All errors display for 5 seconds then return to Normal Operation with previous c
                       │ Wait for tilt│
                       └──────┬───────┘
                              │
-                             │ LIS3DH tilt interrupt
+                             │ ADXL343 tilt interrupt
                              ↓
                       ┌──────────────┐
                       │  WAKE / BOOT │

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -1,10 +1,11 @@
 # Aquavate iOS App - UX Product Requirements Document
 
-**Version:** 1.13
+**Version:** 1.14
 **Date:** 2026-01-25
-**Status:** Approved and Tested (Bottle Level Recent Indicator)
+**Status:** Approved and Tested (Single-Tap Wake)
 
 **Changelog:**
+- **v1.14 (2026-01-25):** Updated "Bottle is Asleep" alert message to reflect single-tap wake capability (Issue #63). Message now says "Tap or tilt your bottle to wake it up". See Section 2.4.
 - **v1.13 (2026-01-25):** Bottle level now shows last known value with "(recent)" indicator when disconnected (Issue #57). Section is hidden until first connection. See Section 2.4.
 - **v1.12 (2026-01-24):** Added Retry/Cancel buttons to "Bottle is Asleep" alert (Issue #52). Users can now tap Retry after waking bottle instead of manually pulling down again. See Section 2.4.
 - **v1.11 (2026-01-24):** Three-color stacked fill for human figure (Issue #50). When behind target, shows orange for deficit up to 20%, red for deficit beyond 20%. See Section 2.9.
@@ -346,7 +347,7 @@ Sarah's Bluetooth is accidentally turned off. When she opens the app, she sees a
 
 **Pull-to-Refresh Alerts:**
 - "Bottle is Asleep" alert if scan times out (~10s) with no devices found
-  - Message: "Tilt your bottle to wake it up, then tap Retry."
+  - Message: "Tap or tilt your bottle to wake it up, then hit Retry."
   - Buttons: **Retry** (triggers new connection attempt) | **Cancel** (dismisses alert)
 - "Sync Error" alert if connection fails or sync interrupted
 - "Bluetooth is turned off" error if Bluetooth unavailable

--- a/firmware/src/config/pins_adafruit.h
+++ b/firmware/src/config/pins_adafruit.h
@@ -3,7 +3,7 @@
  *
  * I2C devices (STEMMA QT / Qwiic):
  *   - NAU7802 ADC (load cell): 0x2A
- *   - LIS3DH accelerometer: 0x18 or 0x19
+ *   - ADXL343 accelerometer: 0x53
  *   - DS3231 RTC: 0x68
  *
  * E-Paper FeatherWing connects via SPI (directly stacked)

--- a/firmware/src/config/pins_sparkfun.h
+++ b/firmware/src/config/pins_sparkfun.h
@@ -3,7 +3,7 @@
  *
  * I2C devices (Qwiic connector):
  *   - NAU7802 ADC (load cell): 0x2A
- *   - LIS3DH accelerometer: 0x18 or 0x19
+ *   - ADXL343 accelerometer: 0x53
  *   - DS3231 RTC: 0x68
  *
  * Waveshare 1.54" E-Paper connects via SPI (requires manual wiring)
@@ -27,7 +27,7 @@
 #define PIN_SPI_MISO        22  // Not used by E-Paper
 #define PIN_SPI_SCK         4
 
-// LIS3DH interrupt pin for wake-on-tilt
+// ADXL343 interrupt pin for wake-on-tilt
 #define PIN_ACCEL_INT       5
 
 // Battery monitoring (via external divider if needed)

--- a/ios/Aquavate/Aquavate/Views/HistoryView.swift
+++ b/ios/Aquavate/Aquavate/Views/HistoryView.swift
@@ -189,7 +189,7 @@ struct HistoryView: View {
                 }
                 Button("Cancel", role: .cancel) { }
             } message: {
-                Text("Tilt your bottle to wake it up, then tap Retry.")
+                Text("Tap or tilt your bottle to wake it up, then hit Retry.")
             }
             .alert("Sync Error", isPresented: $showErrorAlert) {
                 Button("OK", role: .cancel) { }

--- a/ios/Aquavate/Aquavate/Views/HomeView.swift
+++ b/ios/Aquavate/Aquavate/Views/HomeView.swift
@@ -326,7 +326,7 @@ struct HomeView: View {
             }
             Button("Cancel", role: .cancel) { }
         } message: {
-            Text("Tilt your bottle to wake it up, then tap Retry.")
+            Text("Tap or tilt your bottle to wake it up, then hit Retry.")
         }
         .alert("Sync Error", isPresented: $showErrorAlert) {
             Button("OK", role: .cancel) { }


### PR DESCRIPTION
## Summary

- Added single-tap detection as an additional wake method for normal deep sleep mode
- Fixed documentation that incorrectly referenced LIS3DH accelerometer (now ADXL343)
- Updated iOS app alert message to reflect new wake capability

## Changes

**Firmware** (`firmware/src/main.cpp`):
- Modified `configureADXL343Interrupt()` to enable both activity and single-tap interrupts
- INT_ENABLE changed from `0x10` (activity only) to `0x50` (activity + single-tap)
- Tap threshold: 3.0g (same as backpack mode double-tap)
- Tap duration: 10ms max

**iOS App**:
- Updated "Bottle is Asleep" alert in HomeView.swift and HistoryView.swift
- Message now says "Tap or tilt your bottle to wake it up, then hit Retry."

**Documentation**:
- Fixed LIS3DH → ADXL343 in CLAUDE.md, README.md, AGENTS.md, PRD.md, STATE_MACHINE.md
- Updated I2C address comments in pin config files (0x53 for ADXL343)
- Updated IOS-UX-PRD.md to v1.14 with alert message change

See [Plans/050-single-tap-wake.md](Plans/050-single-tap-wake.md) for full implementation details.

## Test plan

- [x] Firmware builds successfully (RAM: 11.6%, Flash: 55.0%)
- [ ] Upload firmware and verify single-tap wakes device from normal sleep
- [ ] Verify sustained motion still wakes device (existing behavior)
- [ ] Verify backpack mode still requires double-tap (unchanged)
- [ ] Build iOS app and verify alert message updated

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)