### PR TITLE
Fix foreground notification display (Issue #56)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,7 +1,7 @@
 # Aquavate - Active Development Progress
 
 **Last Updated:** 2026-01-25
-**Current Branch:** `master` (after merge)
+**Current Branch:** `foreground-notification-fix`
 
 ---
 
@@ -21,6 +21,12 @@ Resume from PROGRESS.md. Ready for next task.
 ---
 
 ## Recently Completed
+
+- ✅ Foreground Notification Fix (Issue #56) - [Plan 051](Plans/051-foreground-notification-fix.md)
+  - Fixed hydration reminders not appearing when app is in foreground
+  - Added UNUserNotificationCenterDelegate to NotificationManager
+  - Implemented willPresent delegate to return banner/sound/badge options
+  - Added didReceive delegate for handling notification taps
 
 - ✅ Single-Tap Wake for Normal Sleep (Issue #63) - [Plan 050](Plans/050-single-tap-wake.md)
   - Added single-tap detection alongside motion wake for normal sleep mode

--- a/Plans/051-foreground-notification-fix.md
+++ b/Plans/051-foreground-notification-fix.md
@@ -1,0 +1,117 @@
+# Plan: Fix Hydration Reminder Notifications (Issue #56)
+
+## Problem
+
+Hydration reminder notifications are scheduled correctly (reminder count increments, logs show success), but **no banner appears on the phone** when the app is in foreground.
+
+## Root Cause
+
+iOS does not display notification banners when the app is in foreground by default. The app must explicitly implement `UNUserNotificationCenterDelegate` and return presentation options.
+
+**Current state of `NotificationManager`:**
+- Does NOT inherit from `NSObject`
+- Does NOT conform to `UNUserNotificationCenterDelegate`
+- Does NOT set the delegate on `UNUserNotificationCenter.current()`
+- Does NOT implement `willPresent` delegate method
+
+## Solution
+
+Modify `NotificationManager` to handle foreground notification presentation.
+
+## Changes
+
+### File: [NotificationManager.swift](ios/Aquavate/Aquavate/Services/NotificationManager.swift)
+
+**1. Update class declaration (line 11-12)**
+
+```swift
+// From:
+@MainActor
+class NotificationManager: ObservableObject {
+
+// To:
+@MainActor
+class NotificationManager: NSObject, ObservableObject, UNUserNotificationCenterDelegate {
+```
+
+**2. Refactor `init()` (lines 59-69)**
+
+NSObject subclasses require `super.init()`. Published properties must be set after super.init(), so load UserDefaults values first:
+
+```swift
+override init() {
+    // Load from UserDefaults before super.init()
+    let isEnabledValue = UserDefaults.standard.bool(forKey: "hydrationRemindersEnabled")
+    let backOnTrackValue = UserDefaults.standard.bool(forKey: "backOnTrackNotificationsEnabled")
+    let dailyLimitValue = UserDefaults.standard.object(forKey: "dailyReminderLimitEnabled") as? Bool ?? true
+    let remindersValue = UserDefaults.standard.integer(forKey: "remindersSentToday")
+    let lastResetValue = UserDefaults.standard.object(forKey: "lastReminderResetDate") as? Date
+
+    super.init()
+
+    // Assign to properties after super.init()
+    self.isEnabled = isEnabledValue
+    self.backOnTrackEnabled = backOnTrackValue
+    self.dailyLimitEnabled = dailyLimitValue
+    self.remindersSentToday = remindersValue
+    self.lastResetDate = lastResetValue
+
+    // Set delegate for foreground presentation
+    notificationCenter.delegate = self
+
+    checkAuthorizationStatus()
+    checkDailyReset()
+}
+```
+
+**3. Add delegate methods (after line 285)**
+
+```swift
+// MARK: - UNUserNotificationCenterDelegate
+
+extension NotificationManager {
+
+    /// Present notifications when app is in foreground
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound, .badge])
+
+        Task { @MainActor in
+            print("[Notifications] Foreground notification presented: \(notification.request.identifier)")
+        }
+    }
+
+    /// Handle notification tap
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let identifier = response.notification.request.identifier
+
+        Task { @MainActor in
+            print("[Notifications] User tapped notification: \(identifier)")
+            // Future: Navigate based on notification type
+        }
+
+        completionHandler()
+    }
+}
+```
+
+## Key Design Points
+
+- **`NSObject` inheritance**: Required for `UNUserNotificationCenterDelegate` (Objective-C protocol)
+- **`nonisolated` methods**: Delegate callbacks come from arbitrary threads
+- **`Task { @MainActor in }`**: Safe pattern for main-thread access (matches BLEManager)
+- **Delegate lifetime**: NotificationManager is a `@StateObject` in AquavateApp, so it persists for app lifetime
+
+## Verification
+
+1. **Build the app** - Ensure no compilation errors
+2. **Foreground test**: Keep app in foreground, wait for a reminder to trigger, verify banner appears
+3. **Background test**: Background the app, verify notifications still work
+4. **Tap test**: Tap a notification, verify log message appears


### PR DESCRIPTION
## Summary

- Fixed hydration reminder notifications not appearing when the iOS app is in foreground
- Root cause: iOS requires explicit `UNUserNotificationCenterDelegate` implementation to present notifications while app is active

## Changes

- `NotificationManager` now inherits from `NSObject` and conforms to `UNUserNotificationCenterDelegate`
- Implemented `willPresent` delegate returning `.banner, .sound, .badge` for foreground display
- Added `didReceive` delegate for handling notification taps (logging only, ready for future navigation)

## Test Plan

- [x] Build succeeds (verified)
- [ ] Foreground test: Keep app open, trigger hydration reminder, verify banner appears
- [ ] Background test: Background the app, verify notifications still work normally
- [ ] Tap test: Tap a notification, verify console shows "[Notifications] User tapped notification: ..."

See [Plans/051-foreground-notification-fix.md](Plans/051-foreground-notification-fix.md) for full implementation details.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)