### PR TITLE
Fix iOS app day boundary bug (Issue #70)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,35 +1,13 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-01-25
-**Current Branch:** `notification-threshold-adjustment`
+**Last Updated:** 2026-01-26
+**Current Branch:** `master`
 
 ---
 
 ## Current Task
 
-**Adjust Hydration Notification Thresholds** - [Plan 053](Plans/053-notification-threshold-adjustment.md) - GitHub Issue #67
-
-Increase minimum deficit thresholds for hydration notifications:
-- Standard (Early Notifications OFF): 50ml → 150ml
-- DEBUG with Early Notifications ON: 10ml → 50ml
-
-### Progress
-
-- [x] Plan approved and copied to Plans/053-notification-threshold-adjustment.md
-- [x] Created branch `notification-threshold-adjustment` from master
-- [x] Update `testModeMinimumDeficit` constant (10 → 50)
-- [x] Update DEBUG threshold in `minimumDeficitForNotification` (50 → 150)
-- [x] Update Release threshold in `minimumDeficitForNotification` (50 → 150)
-- [x] Build verified
-- [x] Create PR (#69)
-
-### Status
-
-**COMPLETE** - PR #69 created and ready for review.
-
-### Files to Modify
-
-1. `ios/Aquavate/Aquavate/Services/HydrationReminderService.swift` - Update threshold constants
+No active task.
 
 ---
 
@@ -37,12 +15,19 @@ Increase minimum deficit thresholds for hydration notifications:
 
 To resume from this progress file:
 ```
-Resume from PROGRESS.md. Working on notification threshold adjustment (Issue #67).
+Resume from PROGRESS.md
 ```
 
 ---
 
 ## Recently Completed
+
+- ✅ iOS Day Boundary Fix (Issue #70) - [Plan 054](Plans/054-ios-day-boundary-fix.md)
+  - Fixed drinks from previous day showing after midnight
+  - Made @FetchRequest predicate dynamic with onAppear and significantTimeChangeNotification
+
+- ✅ Notification Threshold Adjustment (Issue #67) - [Plan 053](Plans/053-notification-threshold-adjustment.md)
+  - Increased minimum deficit thresholds for hydration notifications (50ml → 150ml)
 
 - ✅ iOS Memory Exhaustion Fix (Issue #28) - [Plan 052](Plans/052-ios-memory-exhaustion-fix.md)
   - Fixed memory leaks from WatchConnectivity queue, CoreData @FetchRequest, NotificationManager captures
@@ -52,15 +37,11 @@ Resume from PROGRESS.md. Working on notification threshold adjustment (Issue #67
   - Fixed hydration reminders not appearing when app is in foreground
   - Added UNUserNotificationCenterDelegate to NotificationManager
 
-- ✅ Single-Tap Wake for Normal Sleep (Issue #63) - [Plan 050](Plans/050-single-tap-wake.md)
-  - Added single-tap detection alongside motion wake for normal sleep mode
-
 ---
 
 ## Branch Status
 
 - `master` - Stable baseline
-- `notification-threshold-adjustment` - In progress (Issue #67)
 
 ---
 

--- a/Plans/054-ios-day-boundary-fix.md
+++ b/Plans/054-ios-day-boundary-fix.md
@@ -1,0 +1,68 @@
+# Plan: Fix iOS App Day Boundary Bug
+
+## Problem
+After a date change (midnight), the app shows drinks from the previous day combined with new day's drinks, even after refreshing from the bottle.
+
+## Root Cause
+**The `@FetchRequest` predicate in [HomeView.swift:29](ios/Aquavate/Aquavate/Views/HomeView.swift#L29) is static.**
+
+```swift
+@FetchRequest(
+    sortDescriptors: [...],
+    predicate: NSPredicate(format: "timestamp >= %@",
+        Calendar.current.startOfAquavateDay(for: Date()) as CVarArg),  // ← Date() captured ONCE
+    animation: .default
+)
+private var todaysDrinksCD: FetchedResults<CDDrinkRecord>
+```
+
+The `Date()` call is evaluated once when the view is initialized. If the app stays in memory across midnight (even backgrounded), the predicate never updates, continuing to show yesterday's drinks.
+
+## Fix
+
+**Update the `@FetchRequest.nsPredicate` dynamically** when:
+1. The view appears (`.onAppear`)
+2. The calendar day changes (via `UIApplication.significantTimeChangeNotification`)
+
+### Changes to [HomeView.swift](ios/Aquavate/Aquavate/Views/HomeView.swift)
+
+1. **Remove the static predicate** from `@FetchRequest` initializer (set predicate to `nil` initially)
+
+2. **Add a helper method** to generate the current day's predicate:
+   ```swift
+   private func todaysPredicate() -> NSPredicate {
+       NSPredicate(format: "timestamp >= %@",
+           Calendar.current.startOfAquavateDay(for: Date()) as CVarArg)
+   }
+   ```
+
+3. **Update predicate on appear**:
+   ```swift
+   .onAppear {
+       todaysDrinksCD.nsPredicate = todaysPredicate()
+   }
+   ```
+
+4. **Listen for significant time changes** (date change notification):
+   ```swift
+   .onReceive(NotificationCenter.default.publisher(
+       for: UIApplication.significantTimeChangeNotification)) { _ in
+       todaysDrinksCD.nsPredicate = todaysPredicate()
+   }
+   ```
+
+## Secondary Consideration
+
+The `HydrationReminderService.dailyReset()` method exists but is never called. However, this is less critical because:
+- `syncCurrentStateFromCoreData()` is called on app activation (line 76 in AquavateApp.swift)
+- It re-fetches from CoreData using `getTodaysDrinkRecords()` which dynamically evaluates `Date()`
+
+The CoreData fetch in `HydrationReminderService` is correct; only the `@FetchRequest` UI binding is stale.
+
+## Verification
+
+1. Build the iOS app
+2. Add some drinks before midnight
+3. Wait for (or simulate) date change
+4. Open app and verify only today's drinks appear
+5. Pull-to-refresh and verify totals are correct


### PR DESCRIPTION
## Summary
- Fix drinks from previous day continuing to display after midnight
- Make `@FetchRequest` predicate dynamic instead of static

## Root Cause
The `@FetchRequest` predicate in `HomeView.swift` was evaluated once at view creation. If the app stayed in memory across midnight, the predicate never updated, continuing to show yesterday's drinks combined with today's.

## Changes
- Remove static predicate from `@FetchRequest` initializer
- Add `todaysPredicate()` helper that evaluates `Date()` fresh each call
- Add `.onAppear` modifier to update predicate when view appears
- Add `.onReceive` for `significantTimeChangeNotification` to handle midnight rollover

See [Plan 054](Plans/054-ios-day-boundary-fix.md) for full details.

## Test Plan
- [x] iOS app builds successfully
- [ ] Manual test: verify only today's drinks show after midnight (difficult to test without waiting)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)