### PR TITLE
Fix confusing Activity Stats display with unified sessions view (Issue #74)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,7 +7,7 @@
 
 ## Current Task
 
-None - ready for next issue.
+No active task. Ready for next issue.
 
 ---
 
@@ -21,6 +21,12 @@ Resume from PROGRESS.md
 ---
 
 ## Recently Completed
+
+- ✅ Unified Sessions View Fix (Issue #74) - [Plan 056](Plans/056-unified-sessions-view.md)
+  - Replaced confusing separate "Recent Motion Wakes" and "Backpack Sessions" sections
+  - New unified "Sessions" list shows both types chronologically
+  - Summary changed from "Since Last Charge" to "Last 7 Days"
+  - Users can now clearly see backpack sessions with correct 1+ hour durations
 
 - ✅ Repeated Amber Notification Fix (Issue #72) - [Plan 055](Plans/055-repeated-amber-notification-fix.md)
   - Fixed `lastNotifiedUrgency` not persisting across app restarts (notifications were re-sent)
@@ -47,7 +53,8 @@ Resume from PROGRESS.md
 
 ## Branch Status
 
-- `master` - Stable baseline
+- `master` - Stable baseline (pending PR merge)
+- `unified-sessions-view` - Issue #74 complete, PR pending
 
 ---
 

--- a/Plans/056-unified-sessions-view.md
+++ b/Plans/056-unified-sessions-view.md
@@ -1,0 +1,179 @@
+# Fix: Unified Sessions View for Activity Stats
+
+**Status:** ✅ Complete (2026-01-26)
+**Issue:** [#74](https://github.com/bowerhaus/Aquavate/issues/74)
+
+## Problem
+The current Activity Stats view has two confusing separate sections:
+1. "Recent Motion Wakes" - shows wake periods with misleading "Backpack" badge
+2. "Backpack Sessions" - shows actual backpack mode durations
+
+Users see a short duration (3m 26s) with "Backpack" label and think it's the backpack duration, when it's actually the wake period before entering backpack mode.
+
+## Solution
+Replace the two separate sections with a **single unified "Sessions" list** showing all activity chronologically:
+
+| Timestamp | Duration | Type | Drink |
+|-----------|----------|------|-------|
+| 10:30 AM | 2m 15s | Normal | 💧 |
+| 10:33 AM | 1h 23m | Backpack | - |
+| 11:56 AM | 45s | Normal | - |
+
+Each row shows:
+- **When**: Session start time/date
+- **Duration**: How long the session lasted
+- **Type**: "Normal" (awake/active) or "Backpack" (extended sleep)
+- **Drink**: Water drop icon if a drink was taken during Normal sessions
+
+## Implementation
+
+### File: [ios/Aquavate/Aquavate/Views/ActivityStatsView.swift](ios/Aquavate/Aquavate/Views/ActivityStatsView.swift)
+
+1. **Create a unified session model** to merge both data types:
+```swift
+enum SessionType {
+    case normal(drinkTaken: Bool)
+    case backpack(timerWakes: Int16)
+}
+
+struct UnifiedSession: Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let durationSec: Int32
+    let type: SessionType
+}
+```
+
+2. **Create computed property** to merge and sort both CoreData collections:
+```swift
+private var unifiedSessions: [UnifiedSession] {
+    var sessions: [UnifiedSession] = []
+
+    // Add motion wake events as "Normal" sessions
+    for event in motionWakeEvents {
+        sessions.append(UnifiedSession(
+            id: event.id ?? UUID(),
+            timestamp: event.timestamp ?? Date(),
+            durationSec: event.durationSec,
+            type: .normal(drinkTaken: event.drinkTaken)
+        ))
+    }
+
+    // Add backpack sessions
+    for session in backpackSessions {
+        sessions.append(UnifiedSession(
+            id: session.id ?? UUID(),
+            timestamp: session.startTimestamp ?? Date(),
+            durationSec: session.durationSec,
+            type: .backpack(timerWakes: session.timerWakeCount)
+        ))
+    }
+
+    // Sort by timestamp descending (most recent first)
+    return sessions.sorted { $0.timestamp > $1.timestamp }
+}
+```
+
+3. **Replace the two sections** with a single "Sessions" section (filtered to last 7 days):
+```swift
+if !sessionsLast7Days.isEmpty {
+    Section("Sessions") {
+        ForEach(sessionsLast7Days) { session in
+            HStack {
+                // Timestamp
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(session.timestamp, style: .time)
+                        .font(.headline)
+                    Text(session.timestamp, style: .date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                // Drink indicator (for normal sessions)
+                if case .normal(let drinkTaken) = session.type, drinkTaken {
+                    Image(systemName: "drop.fill")
+                        .foregroundStyle(.blue)
+                        .font(.caption)
+                }
+
+                Spacer()
+
+                // Duration and type
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(formatDuration(Int(session.durationSec)))
+                        .font(.subheadline)
+
+                    // Session type badge
+                    switch session.type {
+                    case .normal:
+                        Text("Normal")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    case .backpack(let timerWakes):
+                        HStack(spacing: 2) {
+                            Image(systemName: "bag")
+                            Text("Backpack")
+                            if timerWakes > 0 {
+                                Text("(\(timerWakes))")
+                            }
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    }
+                }
+            }
+            .padding(.vertical, 2)
+        }
+    }
+}
+```
+
+4. **Update summary section** to show last 7 days totals:
+```swift
+// Computed property for 7-day filtering
+private var sessionsLast7Days: [UnifiedSession] {
+    let sevenDaysAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+    return unifiedSessions.filter { $0.timestamp >= sevenDaysAgo }
+}
+
+private var normalSessionsLast7Days: Int {
+    sessionsLast7Days.filter {
+        if case .normal = $0.type { return true }
+        return false
+    }.count
+}
+
+private var backpackSessionsLast7Days: Int {
+    sessionsLast7Days.filter {
+        if case .backpack = $0.type { return true }
+        return false
+    }.count
+}
+
+// Summary section
+Section("Last 7 Days") {
+    HStack {
+        Image(systemName: "hand.raised.fill")
+            .foregroundStyle(.blue)
+        Text("Normal Sessions")
+        Spacer()
+        Text("\(normalSessionsLast7Days)")
+            .foregroundStyle(.secondary)
+    }
+    HStack {
+        Image(systemName: "bag")
+            .foregroundStyle(.orange)
+        Text("Backpack Sessions")
+        Spacer()
+        Text("\(backpackSessionsLast7Days)")
+            .foregroundStyle(.secondary)
+    }
+}
+```
+
+## Verification
+1. Build the iOS app: `cd ios/Aquavate && xcodebuild -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17' build`
+2. Run in simulator and connect to bottle
+3. Verify Activity Stats shows single "Sessions" section with both types interleaved chronologically
+4. Verify Normal sessions show water drop when drink was taken
+5. Verify Backpack sessions show correct 1+ hour durations with timer wake counts

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -1,10 +1,11 @@
 # Aquavate iOS App - UX Product Requirements Document
 
-**Version:** 1.15
-**Date:** 2026-01-25
-**Status:** Approved and Tested (Notification Threshold Adjustment)
+**Version:** 1.16
+**Date:** 2026-01-26
+**Status:** Approved and Tested (Unified Sessions View)
 
 **Changelog:**
+- **v1.16 (2026-01-26):** Unified Sessions view in Activity Stats (Issue #74). Replaced confusing separate "Recent Motion Wakes" and "Backpack Sessions" sections with single chronological "Sessions" list. Summary changed from "Since Last Charge" to "Last 7 Days". See Section 2.7.
 - **v1.15 (2026-01-25):** Increased notification threshold from 50ml to 150ml behind pace (Issue #67). Early Notifications toggle (DEBUG only) lowers threshold to 50ml. See Section 7.
 - **v1.14 (2026-01-25):** Updated "Bottle is Asleep" alert message to reflect single-tap wake capability (Issue #63). Message now says "Tap or tilt your bottle to wake it up". See Section 2.4.
 - **v1.13 (2026-01-25):** Bottle level now shows last known value with "(recent)" indicator when disconnected (Issue #57). Section is hidden until first connection. See Section 2.4.
@@ -569,43 +570,34 @@ Aquavate uses **midnight** as the daily reset, matching Apple Health. Daily tota
 
 ---
 
-### 2.7 Activity Stats View (Issue #36)
+### 2.7 Activity Stats View (Issue #36, updated Issue #74)
 
 **Purpose:** Diagnostic view for analyzing bottle activity and sleep mode behavior for battery analysis
 
 **Access:** Settings → Diagnostics → Activity Stats
 
-**Layout:**
+**Layout (Updated 2026-01-26 - Unified Sessions):**
 ```
 ┌─────────────────────────────────┐
 │  < Settings    Activity Stats   │
 │                                 │
-│  CURRENT STATUS                 │
+│  LAST 7 DAYS                    │
 │  ┌─────────────────────────────┐│
-│  │ 💧 Normal Mode       Ready  ││  ← Or "🎒 In Backpack Mode"
-│  └─────────────────────────────┘│
-│                                 │
-│  SINCE LAST CHARGE              │
-│  ┌─────────────────────────────┐│
-│  │ ✋ Motion Wakes         42  ││
+│  │ ✋ Normal Sessions      38  ││
 │  ├─────────────────────────────┤│
 │  │ 🎒 Backpack Sessions     3  ││
 │  └─────────────────────────────┘│
 │                                 │
-│  RECENT MOTION WAKES            │
+│  SESSIONS                       │  ← Unified list (both types)
 │  ┌─────────────────────────────┐│
-│  │ 2:30 PM  💧      45s Normal ││  ← Water drop = drink taken
+│  │ 2:30 PM  💧         45s     ││  ← Normal session (water drop = drink)
+│  │ 26 Jan 2026        Normal   ││
 │  ├─────────────────────────────┤│
-│  │ 11:15 AM         32s Normal ││  ← No drop = no drink
+│  │ 11:15 AM           1h 23m   ││  ← Backpack session (orange text)
+│  │ 26 Jan 2026     🎒 Backpack ││
 │  ├─────────────────────────────┤│
-│  │ 9:00 AM  💧    180s Backpack││  ← Entered backpack mode
-│  └─────────────────────────────┘│
-│                                 │
-│  BACKPACK SESSIONS              │
-│  ┌─────────────────────────────┐│
-│  │ Jan 23, 9:03 AM             ││
-│  │ 🕐 1h 30m    ⏱ 90 wakes    ││
-│  │ Exit: Motion detected       ││
+│  │ 9:00 AM             32s     ││  ← Normal session (no drink)
+│  │ 26 Jan 2026        Normal   ││
 │  └─────────────────────────────┘│
 │                                 │
 └─────────────────────────────────┘
@@ -615,16 +607,27 @@ Aquavate uses **midnight** as the daily reset, matching Apple Health. Daily tota
 
 | Element | Source | Description |
 |---------|--------|-------------|
-| Current Status | BLE Activity Summary | Normal mode or backpack mode |
-| Motion Wakes | BLE Activity Summary | Count since last power cycle |
-| Backpack Sessions | BLE Activity Summary | Count since last power cycle |
-| Motion Wake List | BLE Motion Chunks | Time, duration, sleep type, drink flag |
-| Backpack List | BLE Backpack Chunks | Start time, duration, timer wakes, exit reason |
+| Normal Sessions (7d) | CoreData count | Normal sessions in last 7 days |
+| Backpack Sessions (7d) | CoreData count | Backpack sessions in last 7 days |
+| Sessions List | CoreData (merged) | Both types interleaved chronologically, most recent first |
+
+**Session Row Display:**
+
+| Session Type | Timestamp | Duration | Badge | Drink Indicator |
+|--------------|-----------|----------|-------|-----------------|
+| Normal | Time + Date | Seconds/minutes | "Normal" (gray) | 💧 if drink taken |
+| Backpack | Time + Date | Hours/minutes | "🎒 Backpack (N)" (orange) | N/A |
+
+**Design Rationale (Issue #74):**
+- Previous layout had separate "Recent Motion Wakes" and "Backpack Sessions" sections
+- Users confused short wake durations (3m 26s) labeled "Backpack" for backpack duration
+- Unified chronological list makes session flow clearer
+- Backpack sessions now show correct 1+ hour durations prominently
 
 **Drink Taken Indicator:**
-- Blue water drop icon (`drop.fill`) shown next to wake events where user took a drink
-- No icon shown for wakes without a drink
-- Uses bit 7 of `sleep_type` field from firmware
+- Blue water drop icon (`drop.fill`) shown next to Normal sessions where user took a drink
+- No icon shown for Normal sessions without a drink
+- Not applicable to Backpack sessions
 
 **Behavior:**
 - **Lazy loading:** Data fetched only when view appears (not on app launch)

--- a/ios/Aquavate/Aquavate/Views/ActivityStatsView.swift
+++ b/ios/Aquavate/Aquavate/Views/ActivityStatsView.swift
@@ -12,6 +12,22 @@
 import SwiftUI
 import CoreData
 
+// MARK: - Unified Session Model
+
+enum SessionType {
+    case normal(drinkTaken: Bool)
+    case backpack(timerWakes: Int16)
+}
+
+struct UnifiedSession: Identifiable {
+    let id: UUID
+    let timestamp: Date
+    let durationSec: Int32
+    let type: SessionType
+}
+
+// MARK: - Activity Stats View
+
 struct ActivityStatsView: View {
     @EnvironmentObject var bleManager: BLEManager
     @Environment(\.managedObjectContext) private var viewContext
@@ -40,7 +56,7 @@ struct ActivityStatsView: View {
                             Text("Last synced \(lastSync, style: .relative) ago")
                                 .foregroundStyle(.secondary)
                         }
-                    } else if motionWakeEvents.isEmpty && backpackSessions.isEmpty {
+                    } else if unifiedSessions.isEmpty {
                         HStack {
                             Image(systemName: "exclamationmark.triangle")
                                 .foregroundStyle(.orange)
@@ -109,15 +125,15 @@ struct ActivityStatsView: View {
                 }
             }
 
-            // Summary Counts Section (from CoreData)
-            if !motionWakeEvents.isEmpty || !backpackSessions.isEmpty {
-                Section("Since Last Charge") {
+            // Summary Counts Section (Last 7 Days)
+            if !sessionsLast7Days.isEmpty {
+                Section("Last 7 Days") {
                     HStack {
                         Image(systemName: "hand.raised.fill")
                             .foregroundStyle(.blue)
-                        Text("Motion Wakes")
+                        Text("Normal Sessions")
                         Spacer()
-                        Text("\(motionWakeEvents.count)")
+                        Text("\(normalSessionsLast7Days)")
                             .foregroundStyle(.secondary)
                     }
 
@@ -126,44 +142,56 @@ struct ActivityStatsView: View {
                             .foregroundStyle(.orange)
                         Text("Backpack Sessions")
                         Spacer()
-                        Text("\(backpackSessions.count)")
+                        Text("\(backpackSessionsLast7Days)")
                             .foregroundStyle(.secondary)
                     }
                 }
             }
 
-            // Motion Wake Events Section (from CoreData)
-            if !motionWakeEvents.isEmpty {
-                Section("Recent Motion Wakes") {
-                    ForEach(motionWakeEvents.prefix(20), id: \.id) { event in
+            // Unified Sessions List (Last 7 Days)
+            if !sessionsLast7Days.isEmpty {
+                Section("Sessions") {
+                    ForEach(sessionsLast7Days) { session in
                         HStack {
+                            // Timestamp
                             VStack(alignment: .leading, spacing: 2) {
-                                Text(event.timestamp ?? Date(), style: .time)
+                                Text(session.timestamp, style: .time)
                                     .font(.headline)
-                                Text(event.timestamp ?? Date(), style: .date)
+                                Text(session.timestamp, style: .date)
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                             }
-                            if event.drinkTaken {
+
+                            // Drink indicator (for normal sessions)
+                            if case .normal(let drinkTaken) = session.type, drinkTaken {
                                 Image(systemName: "drop.fill")
                                     .foregroundStyle(.blue)
                                     .font(.caption)
                             }
+
                             Spacer()
+
+                            // Duration and type
                             VStack(alignment: .trailing, spacing: 2) {
-                                Text(formatDuration(Int(event.durationSec)))
+                                Text(formatDuration(Int(session.durationSec)))
                                     .font(.subheadline)
-                                if event.sleepType == 1 {  // Extended sleep
-                                    HStack(spacing: 2) {
-                                        Image(systemName: "bag")
-                                        Text("Backpack")
-                                    }
-                                    .font(.caption)
-                                    .foregroundStyle(.orange)
-                                } else {
+
+                                // Session type badge
+                                switch session.type {
+                                case .normal:
                                     Text("Normal")
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
+                                case .backpack(let timerWakes):
+                                    HStack(spacing: 2) {
+                                        Image(systemName: "bag")
+                                        Text("Backpack")
+                                        if timerWakes > 0 {
+                                            Text("(\(timerWakes))")
+                                        }
+                                    }
+                                    .font(.caption)
+                                    .foregroundStyle(.orange)
                                 }
                             }
                         }
@@ -172,45 +200,14 @@ struct ActivityStatsView: View {
                 }
             }
 
-            // Backpack Sessions Section (from CoreData)
-            if !backpackSessions.isEmpty {
-                Section("Backpack Sessions") {
-                    ForEach(backpackSessions, id: \.id) { session in
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack {
-                                Text(session.startTimestamp ?? Date(), style: .date)
-                                Text(session.startTimestamp ?? Date(), style: .time)
-                            }
-                            .font(.headline)
-
-                            HStack {
-                                Label(formatDuration(Int(session.durationSec)), systemImage: "clock")
-                                Spacer()
-                                Label("\(session.timerWakeCount) wakes", systemImage: "timer")
-                            }
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-
-                            HStack {
-                                Text("Exit:")
-                                Text(exitReasonText(Int(session.exitReason)))
-                            }
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        }
-                        .padding(.vertical, 4)
-                    }
-                }
-            }
-
             // Empty State
-            if motionWakeEvents.isEmpty && backpackSessions.isEmpty {
+            if sessionsLast7Days.isEmpty {
                 if bleManager.connectionState.isConnected && bleManager.activityFetchState == .complete {
                     Section {
                         HStack {
                             Image(systemName: "checkmark.circle")
                                 .foregroundStyle(.green)
-                            Text("No activity recorded since last charge")
+                            Text("No activity recorded in the last 7 days")
                                 .foregroundStyle(.secondary)
                         }
                     }
@@ -238,6 +235,56 @@ struct ActivityStatsView: View {
         let bottleId = PersistenceController.shared.getOrCreateDefaultBottle().id
         guard let id = bottleId else { return nil }
         return PersistenceController.shared.getLastActivitySyncDate(for: id)
+    }
+
+    /// Merge motion wake events and backpack sessions into a single sorted list
+    private var unifiedSessions: [UnifiedSession] {
+        var sessions: [UnifiedSession] = []
+
+        // Add motion wake events as "Normal" sessions
+        for event in motionWakeEvents {
+            sessions.append(UnifiedSession(
+                id: event.id ?? UUID(),
+                timestamp: event.timestamp ?? Date(),
+                durationSec: Int32(event.durationSec),
+                type: .normal(drinkTaken: event.drinkTaken)
+            ))
+        }
+
+        // Add backpack sessions
+        for session in backpackSessions {
+            sessions.append(UnifiedSession(
+                id: session.id ?? UUID(),
+                timestamp: session.startTimestamp ?? Date(),
+                durationSec: session.durationSec,
+                type: .backpack(timerWakes: session.timerWakeCount)
+            ))
+        }
+
+        // Sort by timestamp descending (most recent first)
+        return sessions.sorted { $0.timestamp > $1.timestamp }
+    }
+
+    /// Sessions from the last 7 days only
+    private var sessionsLast7Days: [UnifiedSession] {
+        let sevenDaysAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+        return unifiedSessions.filter { $0.timestamp >= sevenDaysAgo }
+    }
+
+    /// Count of normal sessions in the last 7 days
+    private var normalSessionsLast7Days: Int {
+        sessionsLast7Days.filter {
+            if case .normal = $0.type { return true }
+            return false
+        }.count
+    }
+
+    /// Count of backpack sessions in the last 7 days
+    private var backpackSessionsLast7Days: Int {
+        sessionsLast7Days.filter {
+            if case .backpack = $0.type { return true }
+            return false
+        }.count
     }
 
     private var loadingStatusText: String {
@@ -269,18 +316,6 @@ struct ActivityStatsView: View {
         }
     }
 
-    private func exitReasonText(_ reason: Int) -> String {
-        switch reason {
-        case 0:
-            return "Motion detected"
-        case 1:
-            return "Still active"
-        case 2:
-            return "Power cycle"
-        default:
-            return "Unknown"
-        }
-    }
 }
 
 #Preview {


### PR DESCRIPTION
## Summary
- Replaces confusing separate "Recent Motion Wakes" and "Backpack Sessions" sections with a single chronological "Sessions" list
- Users now clearly see backpack sessions with correct 1+ hour durations (previously, short wake durations were confusingly labeled "Backpack")
- Summary section changed from "Since Last Charge" to "Last 7 Days" with filtered session counts

## Test plan
- [x] iOS app builds successfully (`xcodebuild -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17' build`)
- [x] User tested on real device - backpack sessions now show correct durations
- [x] Unified sessions list displays both Normal and Backpack sessions interleaved chronologically
- [x] Normal sessions show water drop icon when drink was taken
- [x] Backpack sessions show bag icon with timer wake count in orange text

See [Plans/056-unified-sessions-view.md](Plans/056-unified-sessions-view.md) for full implementation details.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)