### PR TITLE
Fix NVS fragmentation causing lost drinks (Issue #76)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,7 +7,7 @@
 
 ## Current Task
 
-No active task. Ready for next issue.
+None - ready for next task.
 
 ---
 
@@ -22,35 +22,42 @@ Resume from PROGRESS.md
 
 ## Recently Completed
 
-- ✅ Drink Baseline Hysteresis Fix (Issue #76) - [Plan 057](Plans/057-drink-baseline-hysteresis.md)
+- **LittleFS Drink Storage / NVS Fragmentation Fix (Issue #76)** - [Plan 059](Plans/059-littlefs-drink-storage.md)
+  - Root cause: NVS doesn't support in-place updates, fragments after ~136 drink writes
+  - Solution: LittleFS file storage for drink records (true in-place overwrites)
+  - NVS retained for calibration, settings, daily state (with retry logic)
+  - Also fixed: display garbage on cold boot, IOS_MODE=0 build error
+  - Files: partitions.csv (new), storage_drinks.cpp, drinks.h, main.cpp, display.cpp, and others
+
+- Drink Baseline Hysteresis Fix (Issue #76) - [Plan 057](Plans/057-drink-baseline-hysteresis.md)
   - Fixed drinks sometimes not recorded when second drink taken during same session
   - Added drift threshold (15ml) to prevent baseline contamination during drink detection
   - Only firmware changes (config.h, drinks.cpp)
 
-- ✅ Unified Sessions View Fix (Issue #74) - [Plan 056](Plans/056-unified-sessions-view.md)
+- Unified Sessions View Fix (Issue #74) - [Plan 056](Plans/056-unified-sessions-view.md)
   - Replaced confusing separate "Recent Motion Wakes" and "Backpack Sessions" sections
   - New unified "Sessions" list shows both types chronologically
   - Summary changed from "Since Last Charge" to "Last 7 Days"
   - Users can now clearly see backpack sessions with correct 1+ hour durations
 
-- ✅ Repeated Amber Notification Fix (Issue #72) - [Plan 055](Plans/055-repeated-amber-notification-fix.md)
+- Repeated Amber Notification Fix (Issue #72) - [Plan 055](Plans/055-repeated-amber-notification-fix.md)
   - Fixed `lastNotifiedUrgency` not persisting across app restarts (notifications were re-sent)
   - Updated urgency colors: attention = RGB(247,239,151), overdue = red
   - Human figure now uses smooth gradient from attention to overdue color
   - Added white background layer to fix color blending issues
 
-- ✅ iOS Day Boundary Fix (Issue #70) - [Plan 054](Plans/054-ios-day-boundary-fix.md)
+- iOS Day Boundary Fix (Issue #70) - [Plan 054](Plans/054-ios-day-boundary-fix.md)
   - Fixed drinks from previous day showing after midnight
   - Made @FetchRequest predicate dynamic with onAppear and significantTimeChangeNotification
 
-- ✅ Notification Threshold Adjustment (Issue #67) - [Plan 053](Plans/053-notification-threshold-adjustment.md)
-  - Increased minimum deficit thresholds for hydration notifications (50ml → 150ml)
+- Notification Threshold Adjustment (Issue #67) - [Plan 053](Plans/053-notification-threshold-adjustment.md)
+  - Increased minimum deficit thresholds for hydration notifications (50ml -> 150ml)
 
-- ✅ iOS Memory Exhaustion Fix (Issue #28) - [Plan 052](Plans/052-ios-memory-exhaustion-fix.md)
+- iOS Memory Exhaustion Fix (Issue #28) - [Plan 052](Plans/052-ios-memory-exhaustion-fix.md)
   - Fixed memory leaks from WatchConnectivity queue, CoreData @FetchRequest, NotificationManager captures
   - App now runs 60+ minutes without memory exhaustion
 
-- ✅ Foreground Notification Fix (Issue #56) - [Plan 051](Plans/051-foreground-notification-fix.md)
+- Foreground Notification Fix (Issue #56) - [Plan 051](Plans/051-foreground-notification-fix.md)
   - Fixed hydration reminders not appearing when app is in foreground
   - Added UNUserNotificationCenterDelegate to NotificationManager
 
@@ -59,7 +66,6 @@ Resume from PROGRESS.md
 ## Branch Status
 
 - `master` - Stable baseline
-- `drink-baseline-hysteresis` - Issue #76 complete, PR pending
 
 ---
 

--- a/Plans/058-nvs-write-failure-handling.md
+++ b/Plans/058-nvs-write-failure-handling.md
@@ -1,0 +1,244 @@
+# Plan: Fix NVS Write Failures Causing Lost Drinks
+
+## Issue Summary
+
+GitHub Issue #76 (reopened): Drinks are being lost due to NVS write failures. The drink detection works correctly, but when NVS writes fail, the `recalculateDailyTotals()` function overwrites the in-memory totals with stale NVS data.
+
+**Note:** The original baseline hysteresis fix from plan 057 was already implemented. This is a **different issue**.
+
+## Root Cause Analysis
+
+From the user's logs:
+```
+=== DRINK DETECTED: 161.1ml (POUR) ===
+ERROR: Failed to write drink record to NVS
+ERROR: Failed to write daily state to NVS
+Drinks: Recalculated total = 328ml (2 drinks)   <-- Should be 489ml!
+```
+
+The problem is in [firmware/src/drinks.cpp:256-263](firmware/src/drinks.cpp#L256-L263):
+
+```cpp
+storageSaveDrinkRecord(record);           // Return value IGNORED
+
+g_daily_state.last_recorded_adc = current_adc;
+storageSaveDailyState(g_daily_state);     // Return value IGNORED
+
+recalculateDailyTotals();                 // Overwrites in-memory with stale NVS!
+```
+
+**Why NVS writes might fail:**
+- Flash write errors (transient or wear-related)
+- NVS metadata corruption from interrupted previous writes
+- **Handle contention**: `storage.cpp` keeps `g_preferences` open persistently (line 35) while `storage_drinks.cpp` opens/closes 12+ separate handles per session - all to the same "aquavate" namespace
+
+**Potential future fix for root cause:**
+- Unify NVS access through a single persistent handle, or
+- Close `g_preferences` before drink storage operations, or
+- Use separate namespaces for calibration vs drink data
+
+## Proposed Fix
+
+### 1. Handle NVS Failures Gracefully
+
+Modify the drink detection code to:
+- Check return values from storage functions
+- If NVS save fails, update in-memory totals directly instead of calling `recalculateDailyTotals()`
+- Add retry logic for transient failures
+
+### Changes to [firmware/src/drinks.cpp](firmware/src/drinks.cpp)
+
+**Before (lines 256-263):**
+```cpp
+storageSaveDrinkRecord(record);
+
+g_daily_state.last_recorded_adc = current_adc;
+storageSaveDailyState(g_daily_state);
+
+recalculateDailyTotals();
+```
+
+**After:**
+```cpp
+bool record_saved = storageSaveDrinkRecord(record);
+
+g_daily_state.last_recorded_adc = current_adc;
+bool state_saved = storageSaveDailyState(g_daily_state);
+
+if (record_saved) {
+    // Record saved successfully - recalculate from NVS (authoritative)
+    recalculateDailyTotals();
+} else {
+    // NVS write failed - update in-memory totals directly to preserve the drink
+    Serial.println("WARNING: NVS write failed, updating in-memory totals");
+    g_cached_daily_total_ml += (uint16_t)delta_ml;
+    g_cached_drink_count++;
+}
+```
+
+### 2. Add Retry Logic with ESP-IDF Error Codes
+
+The Arduino `Preferences` wrapper doesn't expose error codes, but we can use the **ESP-IDF NVS API directly** to get detailed error information.
+
+**Logging strategy** (using existing debug level system):
+- **ERROR/WARNING messages**: Unconditional (`Serial.printf`) - always important
+- **Retry attempts**: Use `DEBUG_PRINTF(g_debug_drink_tracking, ...)` macro - shows at debug level 1+
+
+Debug levels: 0=OFF, 1=Events (drink_tracking), 2=+Gestures, 3=+Weight, 4=+Accel, 9=All
+
+Modify [firmware/src/storage_drinks.cpp](firmware/src/storage_drinks.cpp):
+
+**Add includes at top:**
+```cpp
+#include <nvs.h>
+#include <nvs_flash.h>
+#include "config.h"  // For DEBUG_PRINTF macro
+```
+
+**In `storageSaveDrinkRecord()` - replace simple putBytes with retry + error codes:**
+```cpp
+// Try up to 3 times with ESP-IDF API for error codes
+nvs_handle_t nvs_handle;
+esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+if (err != ESP_OK) {
+    Serial.printf("ERROR: nvs_open failed: 0x%x\n", err);  // Unconditional - critical
+    return false;
+}
+
+size_t written = 0;
+esp_err_t last_err = ESP_OK;
+for (int retry = 0; retry < 3 && written != sizeof(DrinkRecord); retry++) {
+    if (retry > 0) {
+        // Conditional - shows at debug level 1+ (drink tracking)
+        DEBUG_PRINTF(g_debug_drink_tracking, "NVS write retry %d/3 (last error: 0x%x)...\n", retry + 1, last_err);
+        delay(10);
+    }
+    last_err = nvs_set_blob(nvs_handle, key, &record_with_id, sizeof(DrinkRecord));
+    if (last_err == ESP_OK) {
+        last_err = nvs_commit(nvs_handle);
+        if (last_err == ESP_OK) {
+            written = sizeof(DrinkRecord);
+        }
+    }
+}
+nvs_close(nvs_handle);
+
+if (written != sizeof(DrinkRecord)) {
+    Serial.printf("ERROR: NVS write failed after 3 retries (error: 0x%x)\n", last_err);  // Unconditional
+    return false;
+}
+```
+
+**Common ESP-IDF NVS error codes to log:**
+- `0x1102` (ESP_ERR_NVS_NOT_INITIALIZED) - NVS not initialized
+- `0x1105` (ESP_ERR_NVS_NOT_ENOUGH_SPACE) - Partition full
+- `0x1108` (ESP_ERR_NVS_REMOVE_FAILED) - Flash write failed
+- `0x110b` (ESP_ERR_NVS_INVALID_STATE) - NVS corrupted
+
+Apply similar pattern to `storageSaveDailyState()` and `storageSaveBufferMetadata()`.
+
+### 3. Display Warning Screen on NVS Failure
+
+When NVS writes fail after all retries, display a warning on the e-paper for 3 seconds so the user knows something went wrong.
+
+**Add to [firmware/src/display.cpp](firmware/src/display.cpp):**
+```cpp
+void displayNVSWarning() {
+    if (!g_display || !g_initialized) return;
+
+    Serial.println("Display: Showing NVS warning");
+
+    g_display->clearBuffer();
+    g_display->setTextColor(EPD_BLACK);
+
+    // Warning text
+    printCentered("Storage", 35, 3);
+    printCentered("Error", 70, 3);
+
+    g_display->display();  // Full refresh
+    delay(3000);           // Show for 3 seconds
+
+    // Redraw main screen
+    drawMainScreen();
+}
+```
+
+**Add declaration to [firmware/include/display.h](firmware/include/display.h):**
+```cpp
+void displayNVSWarning();
+```
+
+**Call from drinks.cpp when NVS fails:**
+```cpp
+if (!record_saved) {
+    Serial.println("WARNING: NVS write failed, updating in-memory totals");
+    g_cached_daily_total_ml += (uint16_t)delta_ml;
+    g_cached_drink_count++;
+    displayNVSWarning();  // Show warning to user
+}
+```
+
+### 4. Add NVS Health Diagnostic (Optional)
+
+Add a function to check NVS health at boot:
+
+**New function in storage_drinks.cpp:**
+```cpp
+bool storageDiagnoseNVS() {
+    nvs_handle_t nvs_handle;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (err != ESP_OK) {
+        Serial.printf("NVS DIAG: Failed to open (0x%x)\n", err);
+        return false;
+    }
+
+    // Try a test write/read cycle
+    uint8_t test = 0xAA;
+    err = nvs_set_u8(nvs_handle, "_nvs_test", test);
+    if (err == ESP_OK) err = nvs_commit(nvs_handle);
+
+    uint8_t read_back = 0;
+    if (err == ESP_OK) err = nvs_get_u8(nvs_handle, "_nvs_test", &read_back);
+
+    nvs_erase_key(nvs_handle, "_nvs_test");
+    nvs_close(nvs_handle);
+
+    if (err == ESP_OK && read_back == 0xAA) {
+        Serial.println("NVS DIAG: Write/read test PASSED");
+        return true;
+    } else {
+        Serial.printf("NVS DIAG: Write/read test FAILED (0x%x)\n", err);
+        return false;
+    }
+}
+```
+
+## Files to Modify
+
+1. [firmware/src/drinks.cpp](firmware/src/drinks.cpp) - Handle NVS failures gracefully, call warning display (lines 256-263)
+2. [firmware/src/storage_drinks.cpp](firmware/src/storage_drinks.cpp) - Add ESP-IDF NVS API with retry logic and error codes
+3. [firmware/include/storage_drinks.h](firmware/include/storage_drinks.h) - Add diagnostic function declaration
+4. [firmware/src/display.cpp](firmware/src/display.cpp) - Add `displayNVSWarning()` function
+5. [firmware/include/display.h](firmware/include/display.h) - Add `displayNVSWarning()` declaration
+
+## Verification
+
+1. Build firmware: `~/.platformio/penv/bin/platformio run`
+2. Manual testing:
+   - Take drinks and verify they're recorded even if NVS has issues
+   - Monitor serial output for any NVS errors
+   - Check that daily totals accumulate correctly
+3. Simulate NVS failure:
+   - Could add a debug flag to force NVS write failure for testing
+
+## Risk Assessment
+
+- **Low risk**: Changes are defensive - they handle error cases that currently cause data loss
+- **No regression**: Normal NVS operation is unchanged
+- **Fallback**: If NVS fails, drinks are still tracked in memory for the current session
+
+## Limitations
+
+- If NVS persistently fails, drinks tracked in memory will be lost when the device goes to sleep (RTC memory preserves baseline but not drink records)
+- A more robust solution would backup failed drink records to RTC memory, but this adds complexity
+- The immediate fix prioritizes not losing drinks during the current session over persistence guarantees

--- a/Plans/059-littlefs-drink-storage.md
+++ b/Plans/059-littlefs-drink-storage.md
@@ -1,0 +1,156 @@
+# Plan: LittleFS Storage for Drink Records (NVS Fragmentation Fix)
+
+**Status:** Complete
+**GitHub Issue:** #76
+**Branch:** `nvs-write-failure-handling`
+**Date:** 2026-01-27
+
+## Summary
+
+Replace NVS-based drink record storage with LittleFS file storage to eliminate fragmentation issues. NVS will continue to be used for calibration, settings, and daily state (with existing retry logic preserved).
+
+## Problem
+
+NVS doesn't support in-place updates - every write marks the old entry as deleted and writes to a new location. After ~136 drink record writes, the partition fragments and returns `ESP_ERR_NVS_NOT_ENOUGH_SPACE` (0x1105), causing drinks to be lost.
+
+## Solution
+
+Store drink records in a LittleFS file with fixed-size slots that support true in-place overwrites. No fragmentation.
+
+---
+
+## Implementation Steps
+
+### 1. Create Custom Partition Table
+
+Create `firmware/partitions.csv`:
+```csv
+# Name,   Type, SubType, Offset,  Size,    Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x140000,
+app1,     app,  ota_1,   0x150000,0x140000,
+littlefs, data, spiffs,  0x290000,0x10000,
+```
+
+- NVS: 20KB (unchanged - calibration, settings, daily state)
+- LittleFS: 64KB (plenty for drink records)
+
+### 2. Update platformio.ini
+
+Change partition reference in `[env:adafruit_feather]`:
+```ini
+board_build.partitions = partitions.csv
+```
+
+### 3. Rewrite storage_drinks.cpp with LittleFS
+
+Replace NVS-based drink record storage with LittleFS file I/O:
+
+```cpp
+#include <LittleFS.h>
+
+#define DRINK_FILE "/drinks.bin"
+#define META_FILE "/meta.bin"
+
+// Fixed-size record file layout:
+// - Record N is at offset N * sizeof(DrinkRecord)
+// - Supports true in-place overwrites
+
+bool storageInitDrinkFS() {
+    if (!LittleFS.begin(true)) {  // true = format if needed
+        Serial.println("ERROR: LittleFS mount failed");
+        return false;
+    }
+    Serial.println("LittleFS mounted");
+    return true;
+}
+```
+
+### 4. Update Header File
+
+Modify `firmware/include/storage_drinks.h`:
+- Add `bool storageInitDrinkFS();` declaration
+- Keep all existing function signatures (API unchanged)
+
+### 5. Initialize LittleFS at Startup
+
+In `firmware/src/main.cpp` setup():
+```cpp
+// Initialize LittleFS for drink storage
+if (!storageInitDrinkFS()) {
+    Serial.println("WARNING: Drink storage unavailable");
+}
+```
+
+### 6. Keep NVS for Non-Drink Data
+
+These stay in NVS (with existing retry logic):
+- Calibration data (`storage.cpp`)
+- Daily state (`storageSaveDailyState` / `storageLoadDailyState`)
+- Settings/debug level
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `firmware/partitions.csv` | **New** - custom partition table with LittleFS |
+| `firmware/platformio.ini` | Point to custom partition table |
+| `firmware/src/storage_drinks.cpp` | Replace NVS drink storage with LittleFS file I/O |
+| `firmware/include/storage_drinks.h` | Add `storageInitDrinkFS()` declaration |
+| `firmware/src/main.cpp` | Call `storageInitDrinkFS()` at startup |
+
+---
+
+## Data Migration
+
+**On first boot after update:**
+- LittleFS partition is auto-formatted (empty)
+- Old NVS drink records are lost (136 records)
+- Calibration and settings preserved in NVS
+- Fresh start with no fragmentation
+
+No migration code needed - starting fresh is cleaner given the fragmentation issues.
+
+---
+
+## What Stays in NVS (with retries)
+
+| Data | Location | Retry Logic |
+|------|----------|-------------|
+| Calibration (zero, scale) | `storage.cpp` | Existing |
+| Daily state (baseline ADC) | `storage_drinks.cpp` | Keep 3-retry with ESP-IDF API |
+| Debug level | `storage.cpp` | Existing |
+
+---
+
+## Verification
+
+1. **Build**: `~/.platformio/penv/bin/platformio run`
+   - Check IRAM usage (should be similar to before)
+   - Verify no compile errors
+
+2. **Upload and test**:
+   - First boot should show "LittleFS mounted"
+   - Calibration should be preserved
+   - Take several drinks, verify recording works
+   - Reboot, verify drinks persist
+   - Take 10+ drinks rapidly, verify no fragmentation errors
+
+3. **Long-term**: Monitor for any storage errors over multiple days
+
+---
+
+## Risk Assessment
+
+- **Low risk**: LittleFS is mature, included in ESP32 Arduino core
+- **Data loss**: Only historical drink records (136) - calibration preserved
+- **Rollback**: Can revert to NVS-only by changing partition table back
+
+---
+
+## Supersedes
+
+This plan supersedes [058-nvs-write-failure-handling.md](058-nvs-write-failure-handling.md), which addressed the same NVS fragmentation issue but with a less robust solution (retries + graceful degradation rather than eliminating the root cause).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -188,17 +188,22 @@ When the bottle hasn't been placed on a stable surface (UPRIGHT_STABLE) for 3 mi
 #### Drink Record Structure
 ```c
 typedef struct {
-    uint32_t timestamp;      // Seconds since last sync (relative time)
+    uint32_t record_id;      // Unique record ID (never reused)
+    uint32_t timestamp;      // Unix epoch timestamp
     int16_t  amount_ml;      // Positive = drink, negative = refill
-    uint16_t bottle_level;   // Current ml remaining after event
-} DrinkRecord;
+    int16_t  bottle_level;   // Current ml remaining after event
+    uint8_t  synced;         // 1 = synced to iOS, 0 = pending
+    uint8_t  type;           // DrinkType: SIP=1, GULP=2, POUR=3, REFILL=4
+    uint8_t  reserved[2];    // Future extensibility
+} DrinkRecord;  // 16 bytes total
 ```
 
-#### Storage Capacity
-- 7 days of history (~500 drinks max)
-- Store in ESP32 NVS or SPIFFS
-- Circular buffer - oldest records overwritten when full
-- Sync flag to track what's been sent to iOS
+#### Storage Implementation
+- **Drink Records:** LittleFS file storage (`/drinks.bin`) - supports true in-place overwrites, no fragmentation
+- **Metadata/Settings:** NVS - calibration, daily state, debug level (rarely written, no fragmentation risk)
+- Circular buffer with 600 record capacity (~30 days history)
+- Oldest records overwritten when full
+- Sync flag tracks what's been sent to iOS
 
 ### 4. BLE Communication
 

--- a/firmware/include/display.h
+++ b/firmware/include/display.h
@@ -37,6 +37,7 @@ DisplayState displayGetState();
 void drawMainScreen();
 void displayBackpackMode();      // Show backpack mode screen with wake instructions (Issue #38)
 void displayTapWakeFeedback();   // Show immediate feedback when waking from tap (blank screen)
+void displayNVSWarning();        // Show storage error warning (3 seconds) when NVS write fails
 
 // Mark display as initialized (used when waking from deep sleep - display image preserved)
 void displayMarkInitialized();

--- a/firmware/include/drinks.h
+++ b/firmware/include/drinks.h
@@ -7,7 +7,7 @@
 #include <Arduino.h>
 #include "storage.h"
 
-// DrinkRecord structure: Stores individual drink/refill events (14 bytes)
+// DrinkRecord structure: Stores individual drink/refill events (16 bytes)
 // Flag bits: 0x01=synced to app, 0x02=day_boundary, 0x04=deleted (soft delete)
 struct DrinkRecord {
     uint32_t record_id;         // Unique incrementing ID for bidirectional sync
@@ -16,6 +16,7 @@ struct DrinkRecord {
     uint16_t bottle_level_ml;   // Bottle water level after event (0-830ml)
     uint8_t  flags;             // Bit flags: 0x01=synced, 0x02=day_boundary, 0x04=deleted
     uint8_t  type;              // Drink type: 0=gulp (<100ml), 1=pour (≥100ml)
+    uint8_t  _reserved[2];      // Reserved for future fields (e.g., temperature, confidence)
 };
 
 // DailyState structure: Tracks drink detection state (8 bytes)

--- a/firmware/include/storage_drinks.h
+++ b/firmware/include/storage_drinks.h
@@ -1,5 +1,8 @@
-// storage_drinks.h - NVS storage for drink records and daily state
+// storage_drinks.h - LittleFS storage for drink records, NVS for daily state
 // Part of the Aquavate smart water bottle firmware
+//
+// Drink records use LittleFS file with fixed-size slots (true in-place overwrites).
+// Daily state uses NVS with retry logic (small, rarely changes).
 
 #ifndef STORAGE_DRINKS_H
 #define STORAGE_DRINKS_H
@@ -7,7 +10,7 @@
 #include <Arduino.h>
 #include "drinks.h"
 
-// CircularBufferMetadata: Tracks circular buffer state in NVS (14 bytes)
+// CircularBufferMetadata: Tracks circular buffer state in LittleFS (14 bytes)
 struct CircularBufferMetadata {
     uint16_t write_index;      // Next write position (0-599)
     uint16_t record_count;     // Number of records stored (0-600)
@@ -16,7 +19,22 @@ struct CircularBufferMetadata {
     uint16_t _reserved;        // Padding for future use
 };
 
-// NVS Storage API
+// ============================================================================
+// LittleFS Initialization
+// ============================================================================
+
+/**
+ * Initialize LittleFS for drink record storage
+ * Must be called before any drink storage functions
+ * Formats the filesystem on first boot after partition change
+ *
+ * @return true if mounted successfully
+ */
+bool storageInitDrinkFS();
+
+// ============================================================================
+// Drink Storage API (LittleFS)
+// ============================================================================
 
 /**
  * Save a drink record to the circular buffer

--- a/firmware/partitions.csv
+++ b/firmware/partitions.csv
@@ -1,0 +1,9 @@
+# Aquavate Custom Partition Table
+# Adds LittleFS partition for drink record storage (eliminates NVS fragmentation)
+#
+# Name,   Type, SubType, Offset,  Size,    Flags
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x140000,
+app1,     app,  ota_1,   0x150000,0x140000,
+spiffs,   data, spiffs,  0x290000,0x10000,

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -40,7 +40,7 @@ build_flags =
     -mno-target-align
     -ffunction-sections
     -fdata-sections
-board_build.partitions = default.csv
+board_build.partitions = partitions.csv
 lib_deps =
     ${env.lib_deps}
     adafruit/Adafruit EPD@^4.5.0

--- a/firmware/src/ble_service.cpp
+++ b/firmware/src/ble_service.cpp
@@ -57,7 +57,7 @@ static BLE_BottleConfig bottleConfig = {
 
 // Device settings cache (loaded from NVS on init)
 static BLE_DeviceSettings deviceSettings = {
-    .flags = DEVICE_SETTINGS_FLAG_SHAKE_EMPTY_ENABLED,  // Default: enabled
+    .flags = 0,  // Default: shake-to-empty disabled
     .reserved1 = 0,
     .reserved2 = 0
 };

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -26,7 +26,7 @@
 //     - IRAM usage: ~82KB / 131KB (62.4%)
 //     - Headroom: ~49.2KB
 
-#define IOS_MODE    1
+#define IOS_MODE    1   // Production: BLE enabled, serial commands disabled
 
 // Auto-configure feature flags based on IOS_MODE
 #if IOS_MODE

--- a/firmware/src/serial_commands.cpp
+++ b/firmware/src/serial_commands.cpp
@@ -732,8 +732,8 @@ static void handleSetExtendedSleepThreshold(char* args) {
         return;
     }
 
-    extern uint32_t g_extended_sleep_threshold_sec;
-    g_extended_sleep_threshold_sec = (uint32_t)seconds;
+    extern uint32_t g_time_since_stable_threshold_sec;
+    g_time_since_stable_threshold_sec = (uint32_t)seconds;
 
     // Save to NVS for persistence
     if (storageSaveExtendedSleepThreshold((uint32_t)seconds)) {

--- a/firmware/src/storage.cpp
+++ b/firmware/src/storage.cpp
@@ -337,11 +337,11 @@ bool storageSaveShakeToEmptyEnabled(bool enabled) {
 
 bool storageLoadShakeToEmptyEnabled() {
     if (!g_initialized) {
-        Serial.println("Storage: Not initialized, using default shake_to_empty_enabled true");
-        return true; // Default: enabled
+        Serial.println("Storage: Not initialized, using default shake_to_empty_enabled false");
+        return false; // Default: disabled
     }
 
-    bool enabled = g_preferences.getBool(KEY_SHAKE_EMPTY_EN, true); // Default: enabled
+    bool enabled = g_preferences.getBool(KEY_SHAKE_EMPTY_EN, false); // Default: disabled
     Serial.print("Storage: Loaded shake_to_empty_enabled = ");
     Serial.println(enabled ? "true" : "false");
     return enabled;

--- a/firmware/src/storage_drinks.cpp
+++ b/firmware/src/storage_drinks.cpp
@@ -1,16 +1,122 @@
-// storage_drinks.cpp - NVS storage implementation for drink tracking
+// storage_drinks.cpp - LittleFS storage for drink records, NVS for daily state
 // Part of the Aquavate smart water bottle firmware
+//
+// Drink records use LittleFS file with fixed-size slots for true in-place overwrites.
+// This eliminates NVS fragmentation that caused ESP_ERR_NVS_NOT_ENOUGH_SPACE errors.
+// Daily state remains in NVS (small, rarely changes) with retry logic.
 
+#include <LittleFS.h>
 #include <Preferences.h>
+#include <nvs.h>
+#include <nvs_flash.h>
 #include "storage_drinks.h"
 #include "config.h"
 
-// Helper function to generate NVS key for drink record at given index
-static void getDrinkRecordKey(uint16_t index, char* key_buf, size_t buf_size) {
-    snprintf(key_buf, buf_size, "drink_%03d", index % DRINK_MAX_RECORDS);
+// External debug flag from main.cpp
+extern bool g_debug_drink_tracking;
+
+// LittleFS file paths
+#define DRINK_FILE "/drinks.bin"
+#define META_FILE "/meta.bin"
+
+// NVS retry configuration (for daily state only)
+#define NVS_MAX_RETRIES 3
+#define NVS_RETRY_DELAY_MS 10
+
+// LittleFS initialization state
+static bool g_littlefs_mounted = false;
+
+// ============================================================================
+// LittleFS Initialization
+// ============================================================================
+
+bool storageInitDrinkFS() {
+    if (g_littlefs_mounted) {
+        return true;  // Already mounted
+    }
+
+    // Mount LittleFS, format if needed (first boot after partition change)
+    if (!LittleFS.begin(true)) {
+        Serial.println("ERROR: LittleFS mount failed");
+        return false;
+    }
+
+    g_littlefs_mounted = true;
+    Serial.println("LittleFS mounted for drink storage");
+
+    // Print filesystem info
+    size_t total = LittleFS.totalBytes();
+    size_t used = LittleFS.usedBytes();
+    Serial.printf("LittleFS: %u bytes used / %u bytes total\n", used, total);
+
+    return true;
+}
+
+// ============================================================================
+// Buffer Metadata (LittleFS)
+// ============================================================================
+
+bool storageLoadBufferMetadata(CircularBufferMetadata& meta) {
+    if (!g_littlefs_mounted) {
+        Serial.println("ERROR: LittleFS not mounted");
+        return false;
+    }
+
+    File file = LittleFS.open(META_FILE, "r");
+    if (!file) {
+        DEBUG_PRINTF(g_debug_drink_tracking, "Metadata file not found (first run)\n");
+        return false;
+    }
+
+    size_t read_size = file.read((uint8_t*)&meta, sizeof(CircularBufferMetadata));
+    file.close();
+
+    if (read_size != sizeof(CircularBufferMetadata)) {
+        Serial.println("ERROR: Failed to read buffer metadata");
+        return false;
+    }
+
+    return true;
+}
+
+bool storageSaveBufferMetadata(const CircularBufferMetadata& meta) {
+    if (!g_littlefs_mounted) {
+        Serial.println("ERROR: LittleFS not mounted");
+        return false;
+    }
+
+    File file = LittleFS.open(META_FILE, "w");
+    if (!file) {
+        Serial.println("ERROR: Failed to open metadata file for writing");
+        return false;
+    }
+
+    size_t written = file.write((const uint8_t*)&meta, sizeof(CircularBufferMetadata));
+    file.close();
+
+    if (written != sizeof(CircularBufferMetadata)) {
+        Serial.println("ERROR: Failed to write buffer metadata");
+        return false;
+    }
+
+    return true;
+}
+
+// ============================================================================
+// Drink Records (LittleFS - fixed-size slots, true in-place overwrites)
+// ============================================================================
+
+// Helper: Calculate file offset for a given slot index
+static size_t getDrinkRecordOffset(uint16_t index) {
+    return (size_t)index * sizeof(DrinkRecord);
 }
 
 bool storageSaveDrinkRecord(const DrinkRecord& record) {
+    if (!g_littlefs_mounted) {
+        Serial.println("ERROR: LittleFS not mounted");
+        return false;
+    }
+
     // Load or initialize metadata
     CircularBufferMetadata meta;
     if (!storageLoadBufferMetadata(meta)) {
@@ -26,22 +132,36 @@ bool storageSaveDrinkRecord(const DrinkRecord& record) {
     DrinkRecord record_with_id = record;
     record_with_id.record_id = meta.next_record_id;
 
-    // Generate key for current write position
-    char key[16];
-    getDrinkRecordKey(meta.write_index, key, sizeof(key));
+    // Open drinks file for read+write (create if doesn't exist)
+    File file = LittleFS.open(DRINK_FILE, "r+");
+    if (!file) {
+        // File doesn't exist, create it
+        file = LittleFS.open(DRINK_FILE, "w");
+        if (!file) {
+            Serial.println("ERROR: Failed to create drinks file");
+            return false;
+        }
+        file.close();
+        file = LittleFS.open(DRINK_FILE, "r+");
+        if (!file) {
+            Serial.println("ERROR: Failed to open drinks file for r+");
+            return false;
+        }
+    }
 
-    // Save drink record
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, false)) {
-        Serial.println("ERROR: Failed to open NVS for drink record write");
+    // Seek to the slot position and write (true in-place overwrite)
+    size_t offset = getDrinkRecordOffset(meta.write_index);
+    if (!file.seek(offset)) {
+        Serial.printf("ERROR: Failed to seek to offset %u\n", offset);
+        file.close();
         return false;
     }
 
-    size_t written = prefs.putBytes(key, &record_with_id, sizeof(DrinkRecord));
-    prefs.end();
+    size_t written = file.write((const uint8_t*)&record_with_id, sizeof(DrinkRecord));
+    file.close();
 
     if (written != sizeof(DrinkRecord)) {
-        Serial.println("ERROR: Failed to write drink record to NVS");
+        Serial.println("ERROR: Failed to write drink record");
         return false;
     }
 
@@ -51,25 +171,26 @@ bool storageSaveDrinkRecord(const DrinkRecord& record) {
         meta.record_count++;
     }
     meta.total_writes++;
-    meta.next_record_id++;  // Increment for next record
+    meta.next_record_id++;
 
     if (!storageSaveBufferMetadata(meta)) {
         Serial.println("WARNING: Drink record saved but metadata update failed");
         return false;
     }
 
-    Serial.print("Drink record saved to ");
-    Serial.print(key);
-    Serial.print(" id=");
-    Serial.print(record_with_id.record_id);
-    Serial.print(" (total: ");
-    Serial.print(meta.record_count);
-    Serial.println(")");
+    Serial.printf("Drink record saved to slot %u, id=%u (total: %u)\n",
+                  (meta.write_index == 0 ? DRINK_MAX_RECORDS - 1 : meta.write_index - 1),
+                  record_with_id.record_id, meta.record_count);
 
     return true;
 }
 
 bool storageLoadLastDrinkRecord(DrinkRecord& record) {
+    if (!g_littlefs_mounted) {
+        Serial.println("ERROR: LittleFS not mounted");
+        return false;
+    }
+
     // Load metadata to find last written index
     CircularBufferMetadata meta;
     if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
@@ -82,18 +203,21 @@ bool storageLoadLastDrinkRecord(DrinkRecord& record) {
         ? (DRINK_MAX_RECORDS - 1)
         : (meta.write_index - 1);
 
-    // Generate key and load record
-    char key[16];
-    getDrinkRecordKey(last_index, key, sizeof(key));
-
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, true)) {
-        Serial.println("ERROR: Failed to open NVS for drink record read");
+    File file = LittleFS.open(DRINK_FILE, "r");
+    if (!file) {
+        Serial.println("ERROR: Failed to open drinks file for reading");
         return false;
     }
 
-    size_t read_size = prefs.getBytes(key, &record, sizeof(DrinkRecord));
-    prefs.end();
+    size_t offset = getDrinkRecordOffset(last_index);
+    if (!file.seek(offset)) {
+        Serial.printf("ERROR: Failed to seek to offset %u\n", offset);
+        file.close();
+        return false;
+    }
+
+    size_t read_size = file.read((uint8_t*)&record, sizeof(DrinkRecord));
+    file.close();
 
     if (read_size != sizeof(DrinkRecord)) {
         Serial.println("ERROR: Failed to read last drink record");
@@ -102,6 +226,265 @@ bool storageLoadLastDrinkRecord(DrinkRecord& record) {
 
     return true;
 }
+
+bool storageGetDrinkRecord(uint16_t index, DrinkRecord& record) {
+    if (!g_littlefs_mounted) {
+        Serial.println("ERROR: LittleFS not mounted");
+        return false;
+    }
+
+    // Load metadata to validate index
+    CircularBufferMetadata meta;
+    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
+        Serial.println("No drink records in storage");
+        return false;
+    }
+
+    // Validate logical index
+    if (index >= meta.record_count) {
+        Serial.printf("ERROR: Invalid record index: %u (max: %u)\n", index, meta.record_count - 1);
+        return false;
+    }
+
+    // Calculate physical index
+    // If buffer is full (record_count == 600), oldest record is at write_index
+    // If buffer is partial, oldest record is at index 0
+    uint16_t physical_index;
+    if (meta.record_count < DRINK_MAX_RECORDS) {
+        physical_index = index;
+    } else {
+        physical_index = (meta.write_index + index) % DRINK_MAX_RECORDS;
+    }
+
+    File file = LittleFS.open(DRINK_FILE, "r");
+    if (!file) {
+        Serial.println("ERROR: Failed to open drinks file for reading");
+        return false;
+    }
+
+    size_t offset = getDrinkRecordOffset(physical_index);
+    if (!file.seek(offset)) {
+        Serial.printf("ERROR: Failed to seek to offset %u\n", offset);
+        file.close();
+        return false;
+    }
+
+    size_t read_size = file.read((uint8_t*)&record, sizeof(DrinkRecord));
+    file.close();
+
+    if (read_size != sizeof(DrinkRecord)) {
+        Serial.printf("ERROR: Failed to read drink record at index %u\n", index);
+        return false;
+    }
+
+    return true;
+}
+
+// Helper: Read record at physical index
+static bool readRecordAtPhysicalIndex(File& file, uint16_t physical_index, DrinkRecord& record) {
+    size_t offset = getDrinkRecordOffset(physical_index);
+    if (!file.seek(offset)) {
+        return false;
+    }
+    return file.read((uint8_t*)&record, sizeof(DrinkRecord)) == sizeof(DrinkRecord);
+}
+
+// Helper: Write record at physical index
+static bool writeRecordAtPhysicalIndex(File& file, uint16_t physical_index, const DrinkRecord& record) {
+    size_t offset = getDrinkRecordOffset(physical_index);
+    if (!file.seek(offset)) {
+        return false;
+    }
+    return file.write((const uint8_t*)&record, sizeof(DrinkRecord)) == sizeof(DrinkRecord);
+}
+
+bool storageMarkSynced(uint16_t start_index, uint16_t count) {
+    (void)start_index;  // Not used - we mark the first N unsynced records
+
+    if (!g_littlefs_mounted) {
+        Serial.println("ERROR: LittleFS not mounted");
+        return false;
+    }
+
+    CircularBufferMetadata meta;
+    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
+        Serial.println("No drink records to mark synced");
+        return false;
+    }
+
+    File file = LittleFS.open(DRINK_FILE, "r+");
+    if (!file) {
+        Serial.println("ERROR: Failed to open drinks file for mark synced");
+        return false;
+    }
+
+    uint16_t marked = 0;
+    for (uint16_t i = 0; i < meta.record_count && marked < count; i++) {
+        uint16_t physical_index;
+        if (meta.record_count < DRINK_MAX_RECORDS) {
+            physical_index = i;
+        } else {
+            physical_index = (meta.write_index + i) % DRINK_MAX_RECORDS;
+        }
+
+        DrinkRecord record;
+        if (!readRecordAtPhysicalIndex(file, physical_index, record)) {
+            Serial.printf("WARNING: Failed to read record at physical index %u\n", physical_index);
+            continue;
+        }
+
+        // Only mark if currently unsynced (bit 0 not set)
+        if ((record.flags & 0x01) == 0) {
+            record.flags |= 0x01;
+            if (writeRecordAtPhysicalIndex(file, physical_index, record)) {
+                marked++;
+            } else {
+                Serial.printf("WARNING: Failed to write synced flag at physical index %u\n", physical_index);
+            }
+        }
+    }
+
+    file.close();
+
+    Serial.printf("Marked %u records as synced\n", marked);
+    return true;
+}
+
+uint16_t storageGetUnsyncedCount() {
+    if (!g_littlefs_mounted) {
+        return 0;
+    }
+
+    CircularBufferMetadata meta;
+    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
+        return 0;
+    }
+
+    File file = LittleFS.open(DRINK_FILE, "r");
+    if (!file) {
+        Serial.println("ERROR: Failed to open drinks file for unsynced count");
+        return 0;
+    }
+
+    uint16_t unsynced_count = 0;
+    for (uint16_t i = 0; i < meta.record_count; i++) {
+        uint16_t physical_index;
+        if (meta.record_count < DRINK_MAX_RECORDS) {
+            physical_index = i;
+        } else {
+            physical_index = (meta.write_index + i) % DRINK_MAX_RECORDS;
+        }
+
+        DrinkRecord record;
+        if (readRecordAtPhysicalIndex(file, physical_index, record)) {
+            if ((record.flags & 0x01) == 0) {
+                unsynced_count++;
+            }
+        }
+    }
+
+    file.close();
+    return unsynced_count;
+}
+
+bool storageGetUnsyncedRecords(DrinkRecord* buffer, uint16_t max_count, uint16_t& out_count) {
+    out_count = 0;
+
+    if (!g_littlefs_mounted) {
+        Serial.println("ERROR: LittleFS not mounted");
+        return false;
+    }
+
+    CircularBufferMetadata meta;
+    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
+        Serial.println("No drink records in storage");
+        return true;  // Not an error, just empty
+    }
+
+    File file = LittleFS.open(DRINK_FILE, "r");
+    if (!file) {
+        Serial.println("ERROR: Failed to open drinks file for unsynced records");
+        return false;
+    }
+
+    for (uint16_t i = 0; i < meta.record_count && out_count < max_count; i++) {
+        uint16_t physical_index;
+        if (meta.record_count < DRINK_MAX_RECORDS) {
+            physical_index = i;
+        } else {
+            physical_index = (meta.write_index + i) % DRINK_MAX_RECORDS;
+        }
+
+        DrinkRecord record;
+        if (readRecordAtPhysicalIndex(file, physical_index, record)) {
+            // Check if unsynced (bit 0 not set) AND not deleted (bit 2 not set)
+            if ((record.flags & 0x01) == 0 && (record.flags & 0x04) == 0) {
+                buffer[out_count] = record;
+                out_count++;
+            }
+        }
+    }
+
+    file.close();
+
+    Serial.printf("Retrieved %u unsynced records\n", out_count);
+    return true;
+}
+
+bool storageMarkDeleted(uint32_t record_id) {
+    if (!g_littlefs_mounted) {
+        Serial.println("ERROR: LittleFS not mounted");
+        return false;
+    }
+
+    CircularBufferMetadata meta;
+    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
+        Serial.println("No drink records in storage");
+        return false;
+    }
+
+    File file = LittleFS.open(DRINK_FILE, "r+");
+    if (!file) {
+        Serial.println("ERROR: Failed to open drinks file for mark deleted");
+        return false;
+    }
+
+    bool found = false;
+    for (uint16_t i = 0; i < meta.record_count; i++) {
+        uint16_t physical_index;
+        if (meta.record_count < DRINK_MAX_RECORDS) {
+            physical_index = i;
+        } else {
+            physical_index = (meta.write_index + i) % DRINK_MAX_RECORDS;
+        }
+
+        DrinkRecord record;
+        if (readRecordAtPhysicalIndex(file, physical_index, record)) {
+            if (record.record_id == record_id) {
+                record.flags |= 0x04;  // Set deleted flag (bit 2)
+                if (writeRecordAtPhysicalIndex(file, physical_index, record)) {
+                    found = true;
+                    Serial.printf("Marked record %u as deleted\n", record_id);
+                } else {
+                    Serial.printf("ERROR: Failed to write deleted flag for record %u\n", record_id);
+                }
+                break;
+            }
+        }
+    }
+
+    file.close();
+
+    if (!found) {
+        Serial.printf("Record %u not found (may have rolled off)\n", record_id);
+    }
+
+    return found;
+}
+
+// ============================================================================
+// Daily State (NVS with retry logic - unchanged from before)
+// ============================================================================
 
 bool storageLoadDailyState(DailyState& state) {
     Preferences prefs;
@@ -122,330 +505,39 @@ bool storageLoadDailyState(DailyState& state) {
 }
 
 bool storageSaveDailyState(const DailyState& state) {
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, false)) {
-        Serial.println("ERROR: Failed to open NVS for daily state write");
+    // Use ESP-IDF NVS API directly for error codes and retry logic
+    nvs_handle_t nvs_handle;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (err != ESP_OK) {
+        Serial.printf("ERROR: nvs_open failed for daily state: 0x%x\n", err);
         return false;
     }
 
-    size_t written = prefs.putBytes("daily_state", &state, sizeof(DailyState));
-    prefs.end();
-
-    if (written != sizeof(DailyState)) {
-        Serial.println("ERROR: Failed to write daily state to NVS");
-        return false;
-    }
-
-    return true;
-}
-
-bool storageLoadBufferMetadata(CircularBufferMetadata& meta) {
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, true)) {
-        Serial.println("ERROR: Failed to open NVS for buffer metadata read");
-        return false;
-    }
-
-    size_t read_size = prefs.getBytes("drink_meta", &meta, sizeof(CircularBufferMetadata));
-    prefs.end();
-
-    if (read_size != sizeof(CircularBufferMetadata)) {
-        Serial.println("Buffer metadata not found (first run)");
-        return false;
-    }
-
-    return true;
-}
-
-bool storageSaveBufferMetadata(const CircularBufferMetadata& meta) {
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, false)) {
-        Serial.println("ERROR: Failed to open NVS for buffer metadata write");
-        return false;
-    }
-
-    size_t written = prefs.putBytes("drink_meta", &meta, sizeof(CircularBufferMetadata));
-    prefs.end();
-
-    if (written != sizeof(CircularBufferMetadata)) {
-        Serial.println("ERROR: Failed to write buffer metadata to NVS");
-        return false;
-    }
-
-    return true;
-}
-
-bool storageGetDrinkRecord(uint16_t index, DrinkRecord& record) {
-    // Load metadata to validate index
-    CircularBufferMetadata meta;
-    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
-        Serial.println("No drink records in storage");
-        return false;
-    }
-
-    // Validate logical index
-    if (index >= meta.record_count) {
-        Serial.print("ERROR: Invalid record index: ");
-        Serial.print(index);
-        Serial.print(" (max: ");
-        Serial.print(meta.record_count - 1);
-        Serial.println(")");
-        return false;
-    }
-
-    // Calculate physical NVS index
-    // If buffer is full (record_count == 600), oldest record is at write_index
-    // If buffer is partial, oldest record is at index 0
-    uint16_t physical_index;
-    if (meta.record_count < DRINK_MAX_RECORDS) {
-        // Buffer not full yet, records start at 0
-        physical_index = index;
-    } else {
-        // Buffer full, oldest record is at write_index
-        physical_index = (meta.write_index + index) % DRINK_MAX_RECORDS;
-    }
-
-    // Generate key and load record
-    char key[16];
-    getDrinkRecordKey(physical_index, key, sizeof(key));
-
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, true)) {
-        Serial.println("ERROR: Failed to open NVS for drink record read");
-        return false;
-    }
-
-    size_t read_size = prefs.getBytes(key, &record, sizeof(DrinkRecord));
-    prefs.end();
-
-    if (read_size != sizeof(DrinkRecord)) {
-        Serial.print("ERROR: Failed to read drink record at index ");
-        Serial.println(index);
-        return false;
-    }
-
-    return true;
-}
-
-bool storageMarkSynced(uint16_t start_index, uint16_t count) {
-    (void)start_index; // Not used - we mark the first N unsynced records
-
-    // Load metadata
-    CircularBufferMetadata meta;
-    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
-        Serial.println("No drink records to mark synced");
-        return false;
-    }
-
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, false)) {
-        Serial.println("ERROR: Failed to open NVS for mark synced");
-        return false;
-    }
-
-    // Iterate through all records and mark the first 'count' unsynced ones as synced
-    // This matches the logic in storageGetUnsyncedRecords
-    uint16_t marked = 0;
-    for (uint16_t i = 0; i < meta.record_count && marked < count; i++) {
-        // Calculate physical index (same logic as storageGetUnsyncedRecords)
-        uint16_t physical_index;
-        if (meta.record_count < DRINK_MAX_RECORDS) {
-            physical_index = i;
-        } else {
-            physical_index = (meta.write_index + i) % DRINK_MAX_RECORDS;
+    // Try up to 3 times with ESP-IDF API for error codes
+    bool write_success = false;
+    esp_err_t last_err = ESP_OK;
+    for (int retry = 0; retry < NVS_MAX_RETRIES; retry++) {
+        if (retry > 0) {
+            DEBUG_PRINTF(g_debug_drink_tracking, "NVS daily state write retry %d/%d (last error: 0x%x)...\n",
+                         retry + 1, NVS_MAX_RETRIES, last_err);
+            delay(NVS_RETRY_DELAY_MS);
         }
-
-        // Load record
-        char key[16];
-        getDrinkRecordKey(physical_index, key, sizeof(key));
-
-        DrinkRecord record;
-        size_t read_size = prefs.getBytes(key, &record, sizeof(DrinkRecord));
-        if (read_size != sizeof(DrinkRecord)) {
-            Serial.print("WARNING: Failed to read record at physical index ");
-            Serial.println(physical_index);
-            continue;
-        }
-
-        // Only mark if currently unsynced (bit 0 not set)
-        if ((record.flags & 0x01) == 0) {
-            // Set synced flag
-            record.flags |= 0x01;
-
-            // Write back
-            size_t written = prefs.putBytes(key, &record, sizeof(DrinkRecord));
-            if (written != sizeof(DrinkRecord)) {
-                Serial.print("WARNING: Failed to write synced flag at physical index ");
-                Serial.println(physical_index);
-            } else {
-                marked++;
-            }
-        }
-    }
-
-    prefs.end();
-
-    Serial.print("Marked ");
-    Serial.print(marked);
-    Serial.println(" records as synced");
-
-    return true;
-}
-
-uint16_t storageGetUnsyncedCount() {
-    // Load metadata
-    CircularBufferMetadata meta;
-    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
-        return 0;
-    }
-
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, true)) {
-        Serial.println("ERROR: Failed to open NVS for unsynced count");
-        return 0;
-    }
-
-    uint16_t unsynced_count = 0;
-
-    // Iterate through all records
-    for (uint16_t i = 0; i < meta.record_count; i++) {
-        // Calculate physical index
-        uint16_t physical_index;
-        if (meta.record_count < DRINK_MAX_RECORDS) {
-            physical_index = i;
-        } else {
-            physical_index = (meta.write_index + i) % DRINK_MAX_RECORDS;
-        }
-
-        // Load record
-        char key[16];
-        getDrinkRecordKey(physical_index, key, sizeof(key));
-
-        DrinkRecord record;
-        size_t read_size = prefs.getBytes(key, &record, sizeof(DrinkRecord));
-        if (read_size == sizeof(DrinkRecord)) {
-            // Check if unsynced (bit 0 not set)
-            if ((record.flags & 0x01) == 0) {
-                unsynced_count++;
-            }
-        }
-    }
-
-    prefs.end();
-
-    return unsynced_count;
-}
-
-bool storageGetUnsyncedRecords(DrinkRecord* buffer, uint16_t max_count, uint16_t& out_count) {
-    out_count = 0;
-
-    // Load metadata
-    CircularBufferMetadata meta;
-    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
-        Serial.println("No drink records in storage");
-        return true; // Not an error, just empty
-    }
-
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, true)) {
-        Serial.println("ERROR: Failed to open NVS for unsynced records");
-        return false;
-    }
-
-    // Iterate through all records in chronological order
-    for (uint16_t i = 0; i < meta.record_count && out_count < max_count; i++) {
-        // Calculate physical index
-        uint16_t physical_index;
-        if (meta.record_count < DRINK_MAX_RECORDS) {
-            physical_index = i;
-        } else {
-            physical_index = (meta.write_index + i) % DRINK_MAX_RECORDS;
-        }
-
-        // Load record
-        char key[16];
-        getDrinkRecordKey(physical_index, key, sizeof(key));
-
-        DrinkRecord record;
-        size_t read_size = prefs.getBytes(key, &record, sizeof(DrinkRecord));
-        if (read_size == sizeof(DrinkRecord)) {
-            // Check if unsynced (bit 0 not set) AND not deleted (bit 2 not set)
-            if ((record.flags & 0x01) == 0 && (record.flags & 0x04) == 0) {
-                buffer[out_count] = record;
-                out_count++;
-            }
-        }
-    }
-
-    prefs.end();
-
-    Serial.print("Retrieved ");
-    Serial.print(out_count);
-    Serial.println(" unsynced records");
-
-    return true;
-}
-
-bool storageMarkDeleted(uint32_t record_id) {
-    // Load metadata
-    CircularBufferMetadata meta;
-    if (!storageLoadBufferMetadata(meta) || meta.record_count == 0) {
-        Serial.println("No drink records in storage");
-        return false;
-    }
-
-    Preferences prefs;
-    if (!prefs.begin(NVS_NAMESPACE, false)) {
-        Serial.println("ERROR: Failed to open NVS for mark deleted");
-        return false;
-    }
-
-    bool found = false;
-
-    // Iterate through all records to find the one with matching ID
-    for (uint16_t i = 0; i < meta.record_count; i++) {
-        // Calculate physical index
-        uint16_t physical_index;
-        if (meta.record_count < DRINK_MAX_RECORDS) {
-            physical_index = i;
-        } else {
-            physical_index = (meta.write_index + i) % DRINK_MAX_RECORDS;
-        }
-
-        // Load record
-        char key[16];
-        getDrinkRecordKey(physical_index, key, sizeof(key));
-
-        DrinkRecord record;
-        size_t read_size = prefs.getBytes(key, &record, sizeof(DrinkRecord));
-        if (read_size == sizeof(DrinkRecord)) {
-            if (record.record_id == record_id) {
-                // Found the record - set deleted flag (bit 2)
-                record.flags |= 0x04;
-
-                // Write back
-                size_t written = prefs.putBytes(key, &record, sizeof(DrinkRecord));
-                if (written == sizeof(DrinkRecord)) {
-                    found = true;
-                    Serial.print("Marked record ");
-                    Serial.print(record_id);
-                    Serial.println(" as deleted");
-                } else {
-                    Serial.print("ERROR: Failed to write deleted flag for record ");
-                    Serial.println(record_id);
-                }
+        last_err = nvs_set_blob(nvs_handle, "daily_state", &state, sizeof(DailyState));
+        if (last_err == ESP_OK) {
+            last_err = nvs_commit(nvs_handle);
+            if (last_err == ESP_OK) {
+                write_success = true;
                 break;
             }
         }
     }
+    nvs_close(nvs_handle);
 
-    prefs.end();
-
-    if (!found) {
-        Serial.print("Record ");
-        Serial.print(record_id);
-        Serial.println(" not found (may have rolled off)");
+    if (!write_success) {
+        Serial.printf("ERROR: NVS daily state write failed after %d retries (error: 0x%x)\n",
+                      NVS_MAX_RETRIES, last_err);
+        return false;
     }
 
-    return found;
+    return true;
 }


### PR DESCRIPTION
## Summary

- Replace NVS-based drink record storage with **LittleFS file storage** to eliminate fragmentation
- NVS doesn't support in-place updates - after ~136 writes it fragments and returns `ESP_ERR_NVS_NOT_ENOUGH_SPACE` (0x1105)
- LittleFS supports true in-place overwrites, no fragmentation

See [Plans/059-littlefs-drink-storage.md](Plans/059-littlefs-drink-storage.md) for full implementation details.

## Changes

- Custom partition table with 64KB LittleFS partition
- Rewritten `storage_drinks.cpp` to use LittleFS file I/O
- NVS retained for calibration, settings, daily state (with existing retry logic)
- DrinkRecord expanded to 16 bytes with 2 reserved bytes for future extensibility
- Fixed display garbage on cold boot (skip until ADC stabilizes)
- Fixed IOS_MODE=0 build error
- Changed shake-to-empty default to disabled

## Test Plan

- [x] Firmware builds successfully (IOS_MODE=1)
- [x] LittleFS mounts on first boot ("LittleFS mounted" in serial output)
- [x] Calibration data preserved from NVS
- [x] Drinks record and persist correctly
- [x] Drinks survive device reboot
- [x] Multiple drinks in same session all recorded
- [ ] Extended testing over multiple days (ongoing)

Closes #76

🤖 Generated with [Claude Code](https://claude.ai/code)