### PR TITLE
Simplify behind-target indicator to faded blue (Issue #81)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-01-28 (Session 10)
+**Last Updated:** 2026-01-28 (Session 11)
 **Current Branch:** `master` (after merge)
 
 ---
@@ -13,6 +13,11 @@
 
 ## Recently Completed
 
+- **Faded Blue Behind Indicator (Issue #81)** - [Plan 061](Plans/061-faded-blue-behind-indicator.md) ✅ COMPLETE
+  - Simplified human figure's "behind target" overlay from amber/red gradient to faded blue (30% opacity)
+  - Removed visual distinction between Attention and Overdue urgency levels
+  - Kept deficit text ("Xml behind target") unchanged
+  - Updated iOS-UX-PRD.md Section 2.9
 - **iOS Calibration Flow (Issue #30)** - [Plan 060](Plans/060-ios-calibration-flow.md) ✅ COMPLETE
   - Bottle-driven calibration with iOS mirroring
   - iOS sends START/CANCEL commands, bottle runs state machine

--- a/Plans/061-faded-blue-behind-indicator.md
+++ b/Plans/061-faded-blue-behind-indicator.md
@@ -1,0 +1,64 @@
+# Plan: Simplify Human Figure Behind Indicator to Faded Blue
+
+## Summary
+
+Replace the amber/red "behind target" overlay in the human figure with a single low-opacity blue fill. Remove visual distinction between Attention and Overdue states while keeping the deficit text.
+
+## Current Behavior
+
+- Solid blue fill from bottom up showing actual water consumed
+- Amber overlay (1-19% behind pace)
+- Red gradient overlay (20%+ behind pace)
+- Text showing "Xml behind" when behind target
+
+## New Behavior
+
+- Solid blue fill from bottom up showing actual water consumed (unchanged)
+- **Single faded blue overlay (~30% opacity)** showing deficit area
+- No color distinction between behind levels
+- Text showing "Xml behind" when behind target (unchanged)
+
+## Files to Modify
+
+### 1. [HumanFigureProgressView.swift](ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift)
+
+**Changes:**
+- Remove `attentionColor` and `overdueColor` constants
+- Add new `behindColor` constant (blue at ~30% opacity)
+- Simplify the deficit overlay logic:
+  - Remove conditional gradient (amber → red)
+  - Replace with single faded blue rectangle
+  - Keep height calculation logic (shows from current fill level to expected level)
+- Keep `isBehindTarget` and deficit text display logic unchanged
+
+**Lines affected:** ~52-117 (deficit zone rendering section)
+
+### 2. No changes to other files
+
+- [HydrationState.swift](ios/Aquavate/Aquavate/Models/HydrationState.swift) - Keep `HydrationUrgency` enum (may be used for notifications)
+- [HydrationReminderService.swift](ios/Aquavate/Aquavate/Services/HydrationReminderService.swift) - Keep urgency calculations
+- [HomeView.swift](ios/Aquavate/Aquavate/Views/HomeView.swift) - No changes needed (still passes urgency, view just ignores it)
+
+## Implementation Details
+
+Replace the gradient-based behind indicator with:
+
+```swift
+// Behind indicator - faded blue showing deficit
+let behindColor = Color.blue.opacity(0.3)
+
+// Simple rectangle fill instead of gradient
+Rectangle()
+    .fill(behindColor)
+    .frame(width: figureWidth, height: expectedHeight)
+    .mask(...)  // Same masking logic as before
+```
+
+## Verification
+
+1. Build the iOS app: `cd ios/Aquavate && xcodebuild -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17' build`
+2. Run in simulator and verify:
+   - Blue fill shows correctly for consumed water
+   - When behind target, faded blue appears above the solid blue
+   - Deficit text ("Xml behind") still displays
+   - No amber or red colors anywhere in the figure

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -1,10 +1,11 @@
 # Aquavate iOS App - UX Product Requirements Document
 
-**Version:** 1.17
-**Date:** 2026-01-27
-**Status:** Approved (Bottle-Driven Calibration)
+**Version:** 1.18
+**Date:** 2026-01-28
+**Status:** Approved (Faded Blue Behind Indicator)
 
 **Changelog:**
+- **v1.18 (2026-01-28):** Simplified behind-target indicator to faded blue (Issue #81). Replaced amber/red gradient with 30% opacity blue. Removes visual distinction between urgency levels while keeping deficit text. See Section 2.9.
 - **v1.17 (2026-01-27):** Bottle-driven calibration (Issue #30). iOS sends START/CANCEL commands, bottle runs state machine and broadcasts state changes, iOS mirrors with rich UI. Simplified to 4 screens: Welcome → Empty → Full → Complete. See Section 2.3.
 - **v1.16 (2026-01-26):** Unified Sessions view in Activity Stats (Issue #74). Replaced confusing separate "Recent Motion Wakes" and "Backpack Sessions" sections with single chronological "Sessions" list. Summary changed from "Since Last Charge" to "Last 7 Days". See Section 2.7.
 - **v1.15 (2026-01-25):** Increased notification threshold from 50ml to 150ml behind pace (Issue #67). Early Notifications toggle (DEBUG only) lowers threshold to 50ml. See Section 7.
@@ -745,7 +746,7 @@ ios/Aquavate/
 
 ---
 
-### 2.9 HomeView Target Visualization (Issue #27)
+### 2.9 HomeView Target Visualization (Issue #27, updated Issue #81)
 
 **Purpose:** Visual pace tracking showing expected vs actual progress
 
@@ -756,10 +757,10 @@ ios/Aquavate/
 │      [Human figure graphic]     │
 │      ┌─────────────────────┐    │
 │      │  ████████░░░░░░░░░  │    │  ← Blue fill = actual
-│      │  ████████████░░░░░  │    │  ← Urgency fill = expected (behind)
+│      │  ████████████░░░░░  │    │  ← Faded blue (30% opacity) = deficit
 │      └─────────────────────┘    │
 │                                 │
-│      250 ml behind target       │  ← Text (urgency colored)
+│      250 ml behind target       │  ← Text (secondary color)
 │                                 │
 └─────────────────────────────────┘
 ```
@@ -769,13 +770,14 @@ ios/Aquavate/
 | State | Visualization |
 |-------|--------------|
 | On track | Blue fill only (actual progress) |
-| Behind target (<20%) | Orange fill showing expected level, blue fill showing actual. Gap indicates deficit. |
-| Behind target (≥20%) | Stacked fill: red (beyond 20% threshold) + orange (up to 20% threshold) + blue (actual). Shows severity of deficit. |
+| Behind target | Blue fill (actual) + faded blue at 30% opacity (deficit zone from actual to expected) |
 
 **Text Display:**
 - Shows "X ml behind target" when rounded deficit ≥ 50ml
-- Text color matches urgency (amber or red)
+- Text uses secondary color (neutral, not urgency-colored)
 - Hidden when on track or deficit < 50ml
+
+**Note:** Urgency levels (attention/overdue) are still calculated for notification purposes but are not visually distinguished in the human figure display.
 
 ---
 

--- a/ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift
+++ b/ios/Aquavate/Aquavate/Components/HumanFigureProgressView.swift
@@ -49,21 +49,6 @@ struct HumanFigureProgressView: View {
         roundedDeficitMl >= 50
     }
 
-    /// Progress level at which overdue begins (80% of expected = 20% behind)
-    private var overdueThresholdProgress: Double {
-        expectedProgress * 0.8
-    }
-
-    /// Whether deficit exceeds the overdue threshold (20%+)
-    private var isOverdue: Bool {
-        progress < overdueThresholdProgress
-    }
-
-    /// Top of orange zone: up to overdue threshold, or expected if not overdue
-    private var orangeTopProgress: Double {
-        isOverdue ? overdueThresholdProgress : expectedProgress
-    }
-
     var body: some View {
         VStack(spacing: 16) {
             ZStack {
@@ -74,40 +59,20 @@ struct HumanFigureProgressView: View {
                     .aspectRatio(contentMode: .fit)
                     .foregroundColor(.white)
 
-                // Deficit zone: gradient from attention (bottom) to overdue (top of head)
+                // Deficit zone: faded blue showing how far behind target
                 // Only show when isBehindTarget (50ml rounded threshold) for consistency with text
-                // Gradient spans from current progress (yellow) to top of head (red), but:
-                // - Only filled up to expected progress level
-                // - White above expected progress (background shows through)
+                // Fills from current progress up to expected progress level
                 if expectedCurrent != nil && isBehindTarget {
                     GeometryReader { geometry in
                         VStack {
                             Spacer(minLength: 0)
-                            // Full gradient from progress to top of head
                             Rectangle()
-                                .fill(
-                                    LinearGradient(
-                                        colors: [HydrationUrgency.attention.color, HydrationUrgency.overdue.color],
-                                        startPoint: .bottom,
-                                        endPoint: .top
-                                    )
-                                )
-                                .frame(height: geometry.size.height * (1.0 - progress))
-                                .opacity(0.7)
+                                .fill(color.opacity(0.3))
+                                .frame(height: geometry.size.height * (expectedProgress - progress))
                         }
                         .offset(y: -geometry.size.height * progress)
                     }
-                    // First mask: clip to expected progress height
-                    .mask(
-                        GeometryReader { geometry in
-                            VStack {
-                                Spacer(minLength: 0)
-                                Rectangle()
-                                    .frame(height: geometry.size.height * expectedProgress)
-                            }
-                        }
-                    )
-                    // Second mask: clip to human figure shape
+                    // Mask to human figure shape
                     .mask(
                         Image("HumanFigureFilled")
                             .resizable()
@@ -181,9 +146,9 @@ struct HumanFigureProgressView: View {
     HumanFigureProgressView(current: 2000, total: 2000, color: .blue, label: "of 2000ml goal")
 }
 
-#Preview("15% behind - orange only") {
-    // 850 actual vs 1000 expected = 15% behind (below 20% overdue threshold)
-    // Shows: blue (850) + orange (850 to 1000)
+#Preview("15% behind") {
+    // 850 actual vs 1000 expected = 15% behind
+    // Shows: blue (850) + faded blue (850 to 1000)
     HumanFigureProgressView(
         current: 850,
         total: 2000,
@@ -195,9 +160,9 @@ struct HumanFigureProgressView: View {
     )
 }
 
-#Preview("30% behind - orange + red") {
-    // 700 actual vs 1000 expected = 30% behind (exceeds 20% overdue threshold)
-    // Shows: blue (700) + orange (700 to 800) + red (800 to 1000)
+#Preview("30% behind") {
+    // 700 actual vs 1000 expected = 30% behind
+    // Shows: blue (700) + faded blue (700 to 1000)
     HumanFigureProgressView(
         current: 700,
         total: 2000,


### PR DESCRIPTION
## Summary

- Replace amber/red gradient with 30% opacity blue for deficit zone in human figure
- Remove visual distinction between Attention and Overdue urgency levels
- Keep deficit text ("Xml behind target") unchanged

See [Plan 061](Plans/061-faded-blue-behind-indicator.md) for full details.

## Test plan

- [x] iOS app builds successfully
- [x] Verified faded blue appears when behind target (~450ml deficit tested)
- [x] Deficit text still displays correctly
- [x] On-track state shows only solid blue (no faded overlay)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)