### PR TITLE
fix: prevent spurious e-paper redraws on wake (#88)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,25 +1,15 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-01-29 (Session 20)
-**Current Branch:** `settings-option5-smart-contextual`
-**GitHub Issue:** #87
-**Plan:** Plans/063-settings-page-redesign.md (not yet created as file)
+**Last Updated:** 2026-01-29 (Session 21)
+**Current Branch:** `display-redraw-on-wake`
+**GitHub Issue:** #88
+**Plan:** [Plans/063-display-redraw-on-wake.md](Plans/063-display-redraw-on-wake.md)
 
 ---
 
 ## Current Task
 
-No active task. Settings Page Redesign (Issue #87) is complete — awaiting PR merge.
-
-### Approach
-
-Iterative implementation: 5 layout options, each on its own branch off `master`, for side-by-side comparison. User picks favourite or hybrid for final version.
-
-### Shared Principles (all options)
-- Disabled + banner when disconnected (never hidden)
-- Calibrate Bottle always visible at top level
-- Connection status merged into Device section (no standalone section)
-- Keep-alive while on Settings via `beginKeepAlive()` / `endKeepAlive()` API in BLEManager
+No active task. Display redraw fix (Issue #88) is complete — awaiting PR merge.
 
 ### Removed Items (all options — decided during Option 2 review)
 
@@ -212,7 +202,8 @@ Files changed (keep-alive):
 
 ## Recently Completed
 
-- **Settings Page Redesign (Issue #87)** - Plan 063 ✅ COMPLETE — Option 5 (Smart Contextual sub-pages) selected. Keep-alive fix, Health/Notification status flags, error message cleanup. iOS-UX-PRD updated.
+- **Display Redraw on Wake Fix (Issue #88)** - [Plan 063](Plans/063-display-redraw-on-wake.md) ✅ COMPLETE — Persisted daily goal in RTC memory, removed dual flag check in displayNeedsUpdate().
+- **Settings Page Redesign (Issue #87)** - Plan 063 ✅ COMPLETE (PR #89) — Option 5 (Smart Contextual sub-pages) selected. Keep-alive fix, Health/Notification status flags, error message cleanup. iOS-UX-PRD updated.
 - **Daily Goal Setting from iOS App (Issue #83)** - [Plan 062](Plans/062-daily-goal-setting.md) ✅ COMPLETE (PR #86)
 - **Calibration Circular Dependency Fix (Issue #84)** - [Plan 062](Plans/062-calibration-circular-dependency.md) ✅ COMPLETE (PR #85)
 - **Faded Blue Behind Indicator (Issue #81)** - [Plan 061](Plans/061-faded-blue-behind-indicator.md) ✅ COMPLETE
@@ -229,12 +220,10 @@ To resume from this progress file:
 ```
 Resume from PROGRESS.md — no active task.
 
-Session 20: Settings Page Redesign (Issue #87) completed.
-- Option 5 (Smart Contextual) selected after reviewing all 5 options on device
-- Final tweaks: reinstated Health/Notification status flags, removed error message row, updated info text
-- BLEManager keep-alive fix committed
-- iOS-UX-PRD.md Section 2.6 updated to reflect new Settings layout
-- PR created referencing #87
+Session 21: Display redraw on wake fix (Issue #88) completed.
+- Persisted g_daily_goal_ml in RTC memory so it survives deep sleep
+- Removed redundant dual-check of g_daily_goal_changed from displayNeedsUpdate()
+- Build successful, PR created.
 ```
 
 ---

--- a/Plans/063-display-redraw-on-wake.md
+++ b/Plans/063-display-redraw-on-wake.md
@@ -1,0 +1,50 @@
+# Fix: E-paper display redraws on every wake (Issue #88)
+
+## Root Cause
+
+After deep sleep, the ESP32 restarts and the static variable `g_daily_goal_ml` in `display.cpp` resets to the compile-time default (`DRINK_DAILY_GOAL_DEFAULT_ML` = 2500). When `displaySetDailyGoal(bleGetDailyGoalMl())` is then called with the NVS-persisted goal (e.g. 3000ml set via iOS), it sees 3000 != 2500 and sets `g_daily_goal_changed = true` — triggering a spurious redraw on every single wake.
+
+Secondary issue: the `g_daily_goal_changed` flag is checked/cleared in two independent code paths (`displayCheckGoalChanged()` and inside `displayNeedsUpdate()`), which is confusing and non-deterministic.
+
+## File to Modify
+
+`firmware/src/display.cpp` — all four changes are in this single file.
+
+## Changes
+
+### 1. Add RTC variable for daily goal (after line 46)
+
+Add `RTC_DATA_ATTR uint16_t rtc_display_daily_goal = 0;` after the existing `rtc_wake_count` declaration.
+
+### 2. Save daily goal in `displaySaveToRTC()` (line ~666)
+
+Add `rtc_display_daily_goal = g_daily_goal_ml;` before the magic number write, alongside the other state saves.
+
+### 3. Restore daily goal in `displayRestoreFromRTC()` (line ~689)
+
+Add `g_daily_goal_ml = rtc_display_daily_goal;` after restoring `battery_percent`, alongside the other state restores.
+
+### 4. Remove dual-check from `displayNeedsUpdate()` (lines 555-560)
+
+Remove the `g_daily_goal_changed` check block (the "2b" section) from `displayNeedsUpdate()`. The flag is already handled by `displayCheckGoalChanged()` in the main loop (main.cpp:1731), which explicitly does a `displayForceUpdate()`. Having two consumers of the same flag is confusing and non-deterministic.
+
+## Why This Works
+
+After the fix, the wake sequence is:
+1. `displayInit()` — `g_daily_goal_ml` defaults to 2500
+2. `displayRestoreFromRTC()` — **restores `g_daily_goal_ml` to the actual value** (e.g. 3000)
+3. `displaySetDailyGoal(bleGetDailyGoalMl())` — NVS returns 3000, compares against 3000 from RTC — **no change** — no flag set — no spurious redraw
+
+## Edge Cases
+
+- **Power cycle** (no valid RTC): restore returns false, goal stays at default (2500). If user had a custom goal, `displaySetDailyGoal()` correctly detects the real change. A full redraw on power cycle is expected.
+- **Goal change via iOS while awake**: BLE callback sets the flag, main loop detects via `displayCheckGoalChanged()`, forces update. Works correctly.
+- **Goal at default (2500)**: RTC saves 2500, restores 2500, NVS returns 2500. No change.
+
+## Verification
+
+1. Build: `cd firmware && ~/.platformio/penv/bin/platformio run`
+2. Upload, set a custom daily goal via iOS app
+3. Let bottle sleep, then wake it
+4. Serial output should NOT show "Display: Daily goal changed" message
+5. E-paper should NOT redraw unless actual content changed

--- a/firmware/src/display.cpp
+++ b/firmware/src/display.cpp
@@ -44,6 +44,7 @@ RTC_DATA_ATTR uint8_t rtc_display_hour = 0;
 RTC_DATA_ATTR uint8_t rtc_display_minute = 0;
 RTC_DATA_ATTR uint8_t rtc_display_battery = 0;
 RTC_DATA_ATTR uint32_t rtc_wake_count = 0;
+RTC_DATA_ATTR uint16_t rtc_display_daily_goal = 0;
 
 // Bitmap data (moved from main.cpp)
 // Water drop icon bitmap (60x60 pixels)
@@ -552,13 +553,6 @@ bool displayNeedsUpdate(float current_water_ml,
         needs_update = true;
     }
 
-    // 2b. Daily goal changed (from BLE config update)
-    if (g_daily_goal_changed) {
-        Serial.println("Display: Daily goal changed - triggering update");
-        g_daily_goal_changed = false;  // Clear flag
-        needs_update = true;
-    }
-
     // 3. Time check (always check if time is valid, update if hour changed or 15+ min elapsed)
     if (g_time_valid) {
         struct timeval tv;
@@ -663,6 +657,7 @@ void displaySaveToRTC() {
     rtc_display_hour = g_display_state.hour;
     rtc_display_minute = g_display_state.minute;
     rtc_display_battery = g_display_state.battery_percent;
+    rtc_display_daily_goal = g_daily_goal_ml;
     rtc_display_magic = RTC_MAGIC_DISPLAY;  // Mark as valid
     rtc_wake_count++;  // Increment wake counter
 
@@ -686,6 +681,7 @@ bool displayRestoreFromRTC() {
     g_display_state.hour = rtc_display_hour;
     g_display_state.minute = rtc_display_minute;
     g_display_state.battery_percent = rtc_display_battery;
+    g_daily_goal_ml = rtc_display_daily_goal;
 
     Serial.printf("Display: Restored from RTC (wake #%lu) - %.0fml, %uml daily, %02u:%02u, %u%% batt\n",
                   rtc_wake_count, rtc_display_water_ml, rtc_display_daily_ml,


### PR DESCRIPTION
## Summary
- Persist `g_daily_goal_ml` in RTC memory so it survives deep sleep, preventing false "goal changed" detection on every wake
- Remove redundant dual-check of `g_daily_goal_changed` flag from `displayNeedsUpdate()` (already handled by `displayCheckGoalChanged()` in main loop)

See [Plans/063-display-redraw-on-wake.md](Plans/063-display-redraw-on-wake.md) for full details.

Closes #88

## Test plan
- [ ] Upload firmware, set a custom daily goal via iOS (e.g. 3000ml)
- [ ] Let bottle sleep, then wake — serial should NOT show "Display: Daily goal changed"
- [ ] E-paper should not flicker/redraw unless actual content changed
- [ ] Power-cycle board — confirm full redraw occurs (expected on fresh boot)
- [ ] Verify build succeeds: `platformio run` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)