### PR TITLE
Fix ADXL343 THRESH_ACT register address and activity threshold (Issue #98)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ pio device monitor         # Serial monitor
 **Important Implementation Details:**
 - ADXL343 INT1 pin must be wired to ESP32 GPIO 27 (not just I2C)
 - ADXL343 needs always-on 3V power (not STEMMA QT which powers down)
-- Wake-on-tilt threshold: 0.80g (0x32)
+- Wake-on-tilt threshold: 0.5g (0x08) — ACTIVITY_WAKE_THRESHOLD in config.h
 - Deep sleep: Dual modes (normal 30s with motion wake, extended 60s with timer wake)
 - RTC memory: Used for display state and drink baseline persistence across sleep
 - NVS: Circular buffer with 600 records (30 days history)

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,18 +1,19 @@
 # Aquavate - Active Development Progress
 
 **Last Updated:** 2026-01-31 (Session 24)
-**Current Branch:** `master`
+**Current Branch:** `fix-adxl343-register-addresses`
 
 ---
 
 ## Current Task
 
-No active task. Ready for next issue.
+None — ready to merge.
 
 ---
 
 ## Recently Completed
 
+- **Fix ADXL343 Register Addresses (Issue #98)** - [Plan 066](Plans/066-fix-adxl343-register-addresses.md) ✅ COMPLETE — Fixed THRESH_ACT register (0x1C → 0x24), separated activity threshold (0.5g) from tap threshold (3.0g), updated PRD.
 - **Double-Tap to Enter Backpack Mode (Issue #99)** - [Plan 065](Plans/065-double-tap-to-sleep.md) ✅ COMPLETE — Double-tap gesture to manually enter extended deep sleep. ADXL343 hardware detection, same 3.0g threshold as wake. PRD updated.
 - **Import/Export Backup (Issue #93)** - [Plan 064](Plans/064-import-export.md) ✅ COMPLETE — JSON backup export/import with Merge and Replace modes. New "Data" category in Settings. iOS-UX-PRD updated.
 - **Display Redraw on Wake Fix (Issue #88)** - [Plan 063](Plans/063-display-redraw-on-wake.md) ✅ COMPLETE — Persisted daily goal in RTC memory, removed dual flag check in displayNeedsUpdate().
@@ -31,7 +32,7 @@ No active task. Ready for next issue.
 
 To resume from this progress file:
 ```
-Resume from PROGRESS.md — No active task. Last completed: Double-tap to enter backpack mode (Issue #99). Related: ADXL343 register bug (Issue #98, separate PR pending).
+Resume from PROGRESS.md — No active task. Last completed: Fix ADXL343 register addresses (Issue #98). THRESH_ACT corrected to 0x24, activity threshold lowered to 0.5g. PR pending merge.
 ```
 
 ---

--- a/Plans/066-fix-adxl343-register-addresses.md
+++ b/Plans/066-fix-adxl343-register-addresses.md
@@ -1,0 +1,43 @@
+# Plan: Fix ADXL343 Register Addresses (Issue #98)
+
+**Status:** ✅ COMPLETE
+
+## Summary
+
+Fix incorrect ADXL343 register address for THRESH_ACT in `configureADXL343Interrupt()` and the diagnostic readback function. Also separate activity wake threshold from tap threshold — the previous 3.0g was too high for tilt-to-pour detection.
+
+## Changes
+
+### 1. [config.h](firmware/src/config.h) — New `ACTIVITY_WAKE_THRESHOLD` constant
+
+- Added `ACTIVITY_WAKE_THRESHOLD 0x08` (0.5g) — separate from `TAP_WAKE_THRESHOLD` (3.0g)
+- Activity detection needs a low threshold to catch tilt/pour motions (~0.7g change at 45°)
+- Tap detection remains at 3.0g for sharp impact detection
+
+### 2. [main.cpp](firmware/src/main.cpp) — `configureADXL343Interrupt()`
+
+- Changed `THRESH_ACT` from `0x1C` (reserved register) to `0x24` (correct address per datasheet)
+- Changed hardcoded `0x30` (3.0g) to `ACTIVITY_WAKE_THRESHOLD` (0.5g)
+- Updated comments and serial output to use the constant
+
+### 3. [main.cpp](firmware/src/main.cpp) — Diagnostic readback
+
+- Changed `readAccelReg(0x1C)` to `readAccelReg(0x24)`
+
+### 4. [PRD.md](docs/PRD.md) — Updated motion wake description
+
+- Corrected threshold from ">3.0g threshold, sustained ~1.6s" to ">0.5g threshold, AC-coupled"
+
+### 5. [AGENTS.md](AGENTS.md) — Updated wake-on-tilt threshold reference
+
+## Behavioural Change
+
+- THRESH_ACT register address corrected: writes now reach the actual hardware register
+- Activity wake threshold: 0.5g (previously effectively 0x00 due to wrong register, plan originally targeted 3.0g but this was too high for tilt detection)
+- Single-tap wake at 3.0g: unaffected
+
+## Verification
+
+1. Build: `cd firmware && ~/.platformio/penv/bin/platformio run` — ✅ SUCCESS
+2. Hardware: verify normal bottle tilt-to-pour wakes from normal sleep
+3. Hardware: verify the diagnostic readback shows correct THRESH_ACT value (0x08 = 0.5g)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -143,7 +143,7 @@ After cutting, verify LED no longer illuminates when board is powered.
 
 #### Wake Triggers
 - **Single-tap wake (normal sleep):** ADXL343 single-tap interrupt (>3.0g threshold, <10ms duration) - firm tap wakes device
-- **Motion wake (normal sleep):** ADXL343 activity interrupt (>3.0g threshold, sustained ~1.6s) - deliberate shake wakes device
+- **Motion wake (normal sleep):** ADXL343 activity interrupt (>0.5g threshold, AC-coupled) - tilt or pick-up wakes device
 - **Rollover wake:** Timer-based wake at midnight daily reset to refresh display with 0ml daily total
   - Ensures display shows correct daily total even if bottle sleeps through rollover
   - Returns to sleep immediately after display refresh (no BLE advertising)

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -139,6 +139,9 @@ extern uint8_t g_daily_intake_display_mode;
 #define DISPLAY_SLEEP_INDICATOR     0
 #define EXTENDED_SLEEP_INDICATOR    1           // Show "Zzzz" before extended sleep (1=enabled)
 
+// Activity detection for normal sleep wake (ADXL343 AC-coupled activity interrupt)
+#define ACTIVITY_WAKE_THRESHOLD     0x08    // 0.5g threshold (8 x 62.5mg/LSB) - detects tilt to pour
+
 // Tap detection for backpack mode wake (ADXL343 double-tap interrupt)
 #define TAP_WAKE_THRESHOLD          0x30    // 3.0g threshold (48 x 62.5mg/LSB) - firm tap required
 #define TAP_WAKE_DURATION           0x10    // 10ms max duration (16 x 625us/LSB) - short sharp tap


### PR DESCRIPTION
## Summary

- Fixed THRESH_ACT register address from `0x1C` (reserved) to `0x24` (correct per datasheet)
- Separated activity wake threshold (0.5g) from tap threshold (3.0g) — 3.0g was too high for tilt-to-pour detection
- Updated diagnostic readback to read from correct register
- Updated PRD and AGENTS.md with corrected threshold values

See [Plan 066](Plans/066-fix-adxl343-register-addresses.md) for full details.

## Test plan

- [x] Firmware build: SUCCESS (Adafruit Feather)
- [x] Hardware: verify tilt-to-pour wakes bottle from normal sleep
- [ ] Hardware: verify diagnostic readback shows THRESH_ACT = 0x08 (0.5g)
- [x] Hardware: verify double-tap still enters/exits backpack mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)