### PR TITLE
fix: backpack mode entry unreachable (Issue #97)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,37 +1,19 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-01-31 (Session 25)
-**Current Branch:** `backpack-mode-entry-fix`
+**Last Updated:** 2026-01-31 (Session 28)
+**Current Branch:** `master`
 
 ---
 
 ## Current Task
 
-**Fix Backpack Mode Entry (Issue #97)** - [Plan 067](Plans/067-backpack-mode-entry-fix.md)
-
-Backpack mode never entered when bottle is horizontal. Root cause: `g_time_since_stable_start` reset on every motion wake (main.cpp:662), making the 180s threshold unreachable across short 30s wake/sleep cycles.
-
-**Solution:** Track consecutive non-stable wake cycles. After 4 wakes without UPRIGHT_STABLE / drink / BLE activity, enter extended sleep instead of normal sleep.
-
-### Progress
-- [x] Plan created (067-backpack-mode-entry-fix.md)
-- [x] Branch created (`backpack-mode-entry-fix` from `master`)
-- [x] GitHub issue created (#97)
-- [x] Add RTC variable (`rtc_spurious_wake_count`) and config constant (`SPURIOUS_WAKE_THRESHOLD`)
-- [x] Modify wake handling in setup() — init `g_wake_was_useful`, preserve/reset counter
-- [x] Add useful-wake markers at UPRIGHT_STABLE, drink detection, BLE activity
-- [x] Add spurious wake check before sleep entry — redirect to extended sleep after threshold
-- [x] Build firmware (SUCCESS — IRAM 94.0%, RAM 11.6%, Flash 59.2%)
-- [ ] User testing
-
-### Files to Modify
-- `firmware/src/main.cpp` — RTC var, wake handling, useful markers, sleep entry decision
-- `firmware/src/config.h` — `SPURIOUS_WAKE_THRESHOLD` constant
+None — ready for next task.
 
 ---
 
 ## Recently Completed
 
+- **Fix Backpack Mode Entry (Issue #97)** - [Plan 067](Plans/067-backpack-mode-entry-fix.md) ✅ COMPLETE — Backpack mode never entered when bottle horizontal. Root cause: per-cycle flags/counters couldn't track state across 30s wake/sleep cycles. Fix: check current gesture (`gesture != GESTURE_UPRIGHT_STABLE`) at sleep time — if not on surface, stay awake and let 180s backpack timer handle it. Four approaches tried; final solution is zero new state, net -1 line.
 - **Fix ADXL343 Register Addresses (Issue #98)** - [Plan 066](Plans/066-fix-adxl343-register-addresses.md) ✅ COMPLETE — Fixed THRESH_ACT register (0x1C → 0x24), separated activity threshold (0.5g) from tap threshold (3.0g), updated PRD.
 - **Double-Tap to Enter Backpack Mode (Issue #99)** - [Plan 065](Plans/065-double-tap-to-sleep.md) ✅ COMPLETE — Double-tap gesture to manually enter extended deep sleep. ADXL343 hardware detection, same 3.0g threshold as wake. PRD updated.
 - **Import/Export Backup (Issue #93)** - [Plan 064](Plans/064-import-export.md) ✅ COMPLETE — JSON backup export/import with Merge and Replace modes. New "Data" category in Settings. iOS-UX-PRD updated.
@@ -51,7 +33,7 @@ Backpack mode never entered when bottle is horizontal. Root cause: `g_time_since
 
 To resume from this progress file:
 ```
-Resume from PROGRESS.md — Working on: Fix backpack mode entry (Issue #97, Plan 067). Branch: backpack-mode-entry-fix. Solution: spurious wake counter — track consecutive non-stable wakes, enter extended sleep after 4. Check progress checklist above for current step.
+Resume from PROGRESS.md — No active task. Ready for next task.
 ```
 
 ---

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -132,7 +132,6 @@ extern uint8_t g_daily_intake_display_mode;
 // When bottle hasn't been stable (UPRIGHT_STABLE) for threshold duration,
 // switch to tap-based wake instead of motion wake to conserve battery
 #define TIME_SINCE_STABLE_THRESHOLD_SEC 180     // 3 minutes without stability triggers backpack mode
-#define SPURIOUS_WAKE_THRESHOLD         4       // Consecutive non-stable wakes before extended sleep
 
 // Display "Zzzz" indicator before entering deep sleep
 // 0 = No display update before sleep (saves battery, no flash)

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -63,7 +63,6 @@ bool g_in_extended_sleep_mode = false;          // Currently using extended slee
 uint32_t g_time_since_stable_threshold_sec = TIME_SINCE_STABLE_THRESHOLD_SEC; // Time without stability before extended sleep (3 min)
 uint32_t g_extended_sleep_timer_sec = 60;       // Timer wake interval for extended sleep (legacy, tap-wake replaced this)
 bool g_force_display_clear_sleep = false;       // Flag to clear Zzzz indicator on wake from extended sleep
-bool g_wake_was_useful = false;                // Track if current wake cycle had user interaction
 bool g_rollover_wake_pending = false;           // Flag to process 4am rollover after initialization
 
 // RTC memory persistence (survives deep sleep)
@@ -73,7 +72,6 @@ RTC_DATA_ATTR unsigned long rtc_time_since_stable_start = 0;
 RTC_DATA_ATTR bool rtc_backpack_screen_shown = false;  // Track if backpack mode screen shown (Issue #38)
 RTC_DATA_ATTR bool rtc_rollover_wake_pending = false;  // True if rollover timer was set for 4am wake
 RTC_DATA_ATTR bool rtc_tap_wake_enabled = false;       // True if in backpack mode expecting tap wake
-RTC_DATA_ATTR uint8_t rtc_spurious_wake_count = 0;    // Consecutive non-stable wakes (for backpack mode entry)
 
 // Sync timeout tracking - regular variable, set at wake time
 // Only extend timeout if NEW drinks recorded during this wake session
@@ -665,7 +663,6 @@ void setup() {
             g_time_since_stable_start = millis();
             rtc_backpack_screen_shown = false;
             g_force_display_clear_sleep = true;
-            rtc_spurious_wake_count = 0;  // Deliberate tap wake - reset counter
             // rtc_tap_wake_enabled cleared after accel reconfig below
         } else {
             // Woke from motion - was in normal sleep, return to normal mode
@@ -673,7 +670,7 @@ void setup() {
             g_in_extended_sleep_mode = false;
             g_time_since_stable_start = millis();
             rtc_backpack_screen_shown = false;
-            g_wake_was_useful = false;  // Will be set true if UPRIGHT_STABLE/drink/BLE activity
+            // Current gesture checked at sleep time (no per-cycle flag needed)
         }
     } else if (wakeup_reason == ESP_SLEEP_WAKEUP_TIMER) {
         // Woke from timer - daily rollover wake (4am reset)
@@ -684,7 +681,6 @@ void setup() {
         g_in_extended_sleep_mode = false;
         rtc_backpack_screen_shown = false;
         rtc_tap_wake_enabled = false;
-        rtc_spurious_wake_count = 0;  // Fresh boot - reset counter
     }
 
     Serial.print("Aquavate v");
@@ -1207,9 +1203,7 @@ void loop() {
     // Check for BLE data activity (sync, commands) and reset activity timeout
     // This ensures device stays awake during active BLE communication
     // Also reset extended sleep timer so 180s threshold doesn't fire during BLE sync
-    // (Plan 067: prevents re-entering backpack mode during active BLE session)
-    // Note: BLE activity does NOT count as useful wake for spurious counter —
-    // only physical interaction (UPRIGHT_STABLE, drink) resets that counter.
+    // (Plan 067: prevents 180s backpack mode timer from firing during active BLE session)
     if (bleCheckDataActivity()) {
         wakeTime = millis();
         g_time_since_stable_start = millis();
@@ -1708,8 +1702,6 @@ void loop() {
                     if (drink_recorded) {
                         // Reset extended sleep timer - drink is unambiguous user interaction
                         g_time_since_stable_start = millis();
-                        g_wake_was_useful = true;
-                        rtc_spurious_wake_count = 0;
                     }
                 }
 
@@ -1948,8 +1940,6 @@ void loop() {
     // Reset extended sleep timer whenever this occurs (not just after threshold)
     if (gesture == GESTURE_UPRIGHT_STABLE) {
         g_time_since_stable_start = millis();
-        g_wake_was_useful = true;
-        rtc_spurious_wake_count = 0;
     }
 
     if (!g_in_extended_sleep_mode
@@ -2008,6 +1998,16 @@ void loop() {
             sleep_blocked = true;
         }
 #endif
+        // Plan 067: If bottle was never placed on a surface (UPRIGHT_STABLE) this
+        // wake cycle, don't sleep — stay awake and let the 180s timer handle
+        // backpack mode entry. This avoids cross-cycle state issues since the
+        // timer runs continuously while awake.
+        if (gesture != GESTURE_UPRIGHT_STABLE && !sleep_blocked) {
+            Serial.println("Sleep deferred - no UPRIGHT_STABLE, waiting for 180s backpack mode timer");
+            wakeTime = millis(); // Reset activity timeout, stay awake
+            sleep_blocked = true;
+        }
+
         // Note: BLE connection alone no longer blocks sleep (Plan 034)
         // Only BLE data activity (sync, commands) resets the activity timeout
         // This prevents the device staying awake forever when connected but idle
@@ -2054,23 +2054,6 @@ void loop() {
                 readAccelReg(0x30);  // INT_SOURCE register
                 Serial.print("INT pin before sleep: ");
                 Serial.println(digitalRead(PIN_ACCEL_INT));
-            }
-
-            // Check for spurious wake pattern (Plan 067: backpack mode entry fix)
-            if (!g_wake_was_useful) {
-                rtc_spurious_wake_count++;
-                Serial.printf("Non-stable wake #%d/%d\n",
-                              rtc_spurious_wake_count, SPURIOUS_WAKE_THRESHOLD);
-
-                if (rtc_spurious_wake_count >= SPURIOUS_WAKE_THRESHOLD) {
-                    Serial.println("Bottle not in use - entering extended sleep (backpack mode)");
-                    g_in_extended_sleep_mode = true;
-                    rtc_spurious_wake_count = 0;
-                    enterExtendedDeepSleep();
-                    // Does not return
-                }
-            } else {
-                rtc_spurious_wake_count = 0;
             }
 
             enterDeepSleep();


### PR DESCRIPTION
## Summary
- Backpack mode was never entered when bottle was horizontal or in a bag — the 180s timer was unreachable across repeated 30s wake/sleep cycles
- Root cause: per-cycle flags and cross-cycle counters couldn't reliably track gesture state
- Fix: at sleep time, check the current gesture directly (`gesture != GESTURE_UPRIGHT_STABLE`) — if not on a surface, stay awake and let the existing 180s backpack timer handle it
- Net result: removed 4 variables and 1 config constant, added a single condition check

See [Plan 067](Plans/067-backpack-mode-entry-fix.md) for full analysis of four approaches evaluated.

## Test plan
- [x] Build succeeds (verified: RAM 11.6%, Flash 59.2%)
- [x] Bottle on table (UPRIGHT_STABLE) → normal sleep after 30s inactivity
- [x] Bottle held in hand (not UPRIGHT_STABLE) → stays awake → extended sleep after 180s
- [x] Bottle in backpack → stays awake → extended sleep after 180s
- [x] Double-tap still wakes from backpack mode
- [x] Normal drink detection unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)