### PR TITLE
fix: auto-recovery after battery depletion (#107)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-02-02 (Session 29)
+**Last Updated:** 2026-02-08 (Session 31)
 **Current Branch:** `master`
 
 ---
@@ -13,6 +13,7 @@ None — ready for next task.
 
 ## Recently Completed
 
+- **Fix: Auto-recovery after battery depletion (Issue #107)** - [Plan 069](Plans/069-battery-depletion-recovery.md) ✅ COMPLETE — ESP32 could get stuck in deep sleep after battery depletion because ADXL343 loses interrupt config while ESP32 RTC domain persists. Fix: periodic health-check timer wake (every 2 hours) added to both normal and extended deep sleep modes. Device boots normally on health-check wake, auto-sleeps after 30s. Battery impact ~1mAh/day. PRD updated.
 - **Fix False Double-Tap Triggering Backpack Mode (Issue #103)** - [Plan 068](Plans/068-false-double-tap-backpack-fix.md) ✅ COMPLETE — Setting bottle down on hard surface created bounce pattern matching ADXL343 double-tap, falsely entering backpack mode. Fix: gate double-tap handler on `g_has_been_upright_stable` flag — bottle must have settled on surface (2s stability) before double-tap can trigger backpack mode. ~5 lines changed.
 - **Fix Backpack Mode Entry (Issue #97)** - [Plan 067](Plans/067-backpack-mode-entry-fix.md) ✅ COMPLETE — Backpack mode never entered when bottle horizontal. Root cause: per-cycle flags/counters couldn't track state across 30s wake/sleep cycles. Fix: check current gesture (`gesture != GESTURE_UPRIGHT_STABLE`) at sleep time — if not on surface, stay awake and let 180s backpack timer handle it. Four approaches tried; final solution is zero new state, net -1 line.
 - **Fix ADXL343 Register Addresses (Issue #98)** - [Plan 066](Plans/066-fix-adxl343-register-addresses.md) ✅ COMPLETE — Fixed THRESH_ACT register (0x1C → 0x24), separated activity threshold (0.5g) from tap threshold (3.0g), updated PRD.
@@ -34,7 +35,7 @@ None — ready for next task.
 
 To resume from this progress file:
 ```
-Resume from PROGRESS.md — No active task. Ready for next task.
+Resume from PROGRESS.md — No active task. Ready for next task. Branch: master.
 ```
 
 ---

--- a/Plans/069-battery-depletion-recovery.md
+++ b/Plans/069-battery-depletion-recovery.md
@@ -1,0 +1,116 @@
+# Fix: Auto-recovery after battery depletion
+
+## Context
+
+The bottle is a sealed autonomous device with no accessible reset button. When the battery dies and USB charger is reconnected, the ESP32 doesn't restart — the only workaround is re-uploading firmware (which forces a hard reset via DTR/RTS).
+
+**Root cause:** The ADXL343 accelerometer loses its interrupt configuration when its supply voltage drops below ~2.0V, but the ESP32's RTC domain can survive on residual charge (~10μA). This means:
+
+1. Device enters deep sleep — ADXL343 configured to drive INT pin HIGH on motion/tap
+2. Battery voltage drops below ADXL343 minimum → accelerometer resets to defaults, interrupt config lost
+3. ESP32 RTC domain still alive → still in deep sleep, waiting for GPIO 27 HIGH (EXT0 wake)
+4. Charger reconnected, user tilts bottle — but ADXL343 INT pin stays LOW (no interrupt configured)
+5. ESP32 never gets wake signal → stuck forever
+
+Neither sleep mode has a fallback timer, so the device stays asleep indefinitely.
+
+## Solution: Periodic health-check timer wake
+
+Add a timer wake source to **both** deep sleep modes so the device periodically wakes up, even without motion or tap input. This ensures the device recovers automatically after power is restored.
+
+## Changes
+
+### 1. Add config constant — [config.h](firmware/src/config.h)
+
+Add to the Power Management section (~line 134, after `TIME_SINCE_STABLE_THRESHOLD_SEC`):
+
+```cpp
+// Health-check wake: periodic timer wake in all deep sleep modes
+// Ensures device auto-recovers after battery depletion + recharge
+// Battery impact: ~1mAh/day (negligible vs 400-1000mAh LiPo)
+#define HEALTH_CHECK_WAKE_INTERVAL_SEC  7200    // 2 hours
+```
+
+### 2. Add RTC flag to distinguish health-check from rollover — [main.cpp](firmware/src/main.cpp) (~line 73)
+
+```cpp
+RTC_DATA_ATTR bool rtc_health_check_wake = false;  // True if timer was set for health check (not rollover)
+```
+
+### 3. Modify `enterDeepSleep()` — [main.cpp](firmware/src/main.cpp:454)
+
+Replace the current rollover-only timer logic (lines 504-517) with:
+
+```cpp
+// Configure timer wake: use minimum of rollover time and health-check interval
+uint32_t timer_seconds = HEALTH_CHECK_WAKE_INTERVAL_SEC;
+rtc_health_check_wake = true;
+
+uint32_t seconds_until_rollover = getSecondsUntilRollover();
+if (seconds_until_rollover > 0 && seconds_until_rollover < 24 * 3600) {
+    uint32_t rollover_with_buffer = seconds_until_rollover + 60;
+    if (rollover_with_buffer < timer_seconds) {
+        timer_seconds = rollover_with_buffer;
+        rtc_health_check_wake = false;  // This is a rollover wake
+    }
+    rtc_rollover_wake_pending = true;
+} else {
+    rtc_rollover_wake_pending = false;
+}
+
+uint64_t timer_us = (uint64_t)timer_seconds * 1000000ULL;
+esp_sleep_enable_timer_wakeup(timer_us);
+Serial.printf("Sleep timer set: %lu seconds (%s)\n", timer_seconds,
+              rtc_health_check_wake ? "health check" : "rollover");
+```
+
+### 4. Modify `enterExtendedDeepSleep()` — [main.cpp](firmware/src/main.cpp:411)
+
+Add timer wake **alongside** the existing EXT0 tap wake (before `esp_deep_sleep_start()`):
+
+```cpp
+// Add periodic health-check timer (ESP32 supports multiple wake sources)
+uint64_t timer_us = (uint64_t)HEALTH_CHECK_WAKE_INTERVAL_SEC * 1000000ULL;
+esp_sleep_enable_timer_wakeup(timer_us);
+rtc_health_check_wake = true;
+Serial.printf("Health-check timer set: %d seconds\n", HEALTH_CHECK_WAKE_INTERVAL_SEC);
+```
+
+### 5. Update timer wake handling in `setup()` — [main.cpp](firmware/src/main.cpp:678)
+
+Replace the current timer wake case:
+
+```cpp
+} else if (wakeup_reason == ESP_SLEEP_WAKEUP_TIMER) {
+    if (rtc_health_check_wake) {
+        Serial.println("Timer wake detected (health check)");
+        // Health check: go through normal boot, will auto-sleep after inactivity timeout
+        // If in backpack mode, preserve that state
+        if (rtc_tap_wake_enabled) {
+            // Was in extended sleep - stay in backpack mode context
+            Serial.println("  (from backpack mode - will re-evaluate)");
+        }
+        g_time_since_stable_start = millis();
+    } else {
+        Serial.println("Timer wake detected (daily rollover)");
+    }
+}
+```
+
+## What happens on health-check wake
+
+1. Device boots normally through `setup()`
+2. All sensors initialize, display updates if needed
+3. No user interaction → activity timeout expires after 30s
+4. Device goes back to sleep with another health-check timer
+5. Cycle continues — device is alive and will respond to motion/tap as normal
+
+After battery depletion + charger reconnect: within at most 2 hours the device wakes, boots, and resumes normal operation.
+
+## Verification
+
+1. Build firmware: `cd firmware && ~/.platformio/penv/bin/platformio run`
+2. Upload and monitor serial output
+3. Let device enter normal deep sleep — confirm serial shows "Sleep timer set: N seconds (health check)" or "(rollover)" with the shorter value
+4. Let device enter extended/backpack sleep — confirm serial shows health-check timer alongside tap wake
+5. Wait for a health-check wake (or temporarily set interval to 60s for testing) — confirm device wakes, boots normally, then re-sleeps after 30s

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -147,13 +147,18 @@ After cutting, verify LED no longer illuminates when board is powered.
 - **Rollover wake:** Timer-based wake at midnight daily reset to refresh display with 0ml daily total
   - Ensures display shows correct daily total even if bottle sleeps through rollover
   - Returns to sleep immediately after display refresh (no BLE advertising)
+- **Health-check wake:** Periodic timer wake (every 2 hours) in both normal and extended sleep modes
+  - Ensures device auto-recovers after battery depletion + recharge (ADXL343 loses interrupt config when power drops)
+  - Device boots normally, auto-sleeps after 30s inactivity timeout
+  - In normal sleep, timer is `min(rollover, health-check)` — rollover takes priority when closer
+  - Battery impact: ~1mAh/day (negligible vs 400-1000mAh LiPo)
 - **Double-tap wake (backpack mode only):** ADXL343 double-tap interrupt for waking from extended sleep
 
 #### Backpack Mode (Extended Sleep)
 When the bottle hasn't been placed on a stable surface (UPRIGHT_STABLE) for 3 minutes, it enters "backpack mode":
 - Display shows "backpack mode" with instructions: "double-tap firmly to wake up"
 - ADXL343 reconfigured from motion detection to double-tap detection
-- No periodic timer wakes (maximum battery savings)
+- Health-check timer wake every 2 hours (auto-recovery from battery depletion)
 - User double-taps bottle firmly to exit backpack mode
 - Immediate "waking" feedback shown before sensor initialization
 - After wake, ADXL343 restored to normal motion detection

--- a/firmware/src/activity_stats.cpp
+++ b/firmware/src/activity_stats.cpp
@@ -96,6 +96,11 @@ void activityStatsRecordWakeStart(WakeReason reason) {
         activityStatsFinalizeBackpackSession(EXIT_MOTION_DETECTED);
     }
 
+    // If timer wake during backpack mode, increment session counter
+    if (reason == WAKE_REASON_TIMER && rtc_activity_buffer.current_session_start != 0) {
+        rtc_activity_buffer.current_timer_wake_count++;
+    }
+
     // Start tracking this wake
     g_current_wake.wake_timestamp = getCurrentUnixTime();
     g_current_wake.wake_millis = millis();

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -133,6 +133,11 @@ extern uint8_t g_daily_intake_display_mode;
 // switch to tap-based wake instead of motion wake to conserve battery
 #define TIME_SINCE_STABLE_THRESHOLD_SEC 180     // 3 minutes without stability triggers backpack mode
 
+// Health-check wake: periodic timer wake in all deep sleep modes
+// Ensures device auto-recovers after battery depletion + recharge
+// Battery impact: ~1mAh/day (negligible vs 400-1000mAh LiPo)
+#define HEALTH_CHECK_WAKE_INTERVAL_SEC  7200    // 2 hours
+
 // Display "Zzzz" indicator before entering deep sleep
 // 0 = No display update before sleep (saves battery, no flash)
 // 1 = Show "Zzzz" indicator before sleep (visual feedback)


### PR DESCRIPTION
## Summary

- Add periodic health-check timer wake (every 2 hours) to both normal and extended deep sleep modes
- Prevents device getting stuck in deep sleep after battery depletion + recharge (ADXL343 loses interrupt config while ESP32 RTC domain persists)
- Health-check wakes recorded as individual activity events for iOS sleep analysis

See [Plan 069](Plans/069-battery-depletion-recovery.md) for full details.

## Changes

- **`config.h`** — Added `HEALTH_CHECK_WAKE_INTERVAL_SEC` (7200s / 2 hours)
- **`main.cpp`** — RTC flag to distinguish health-check vs rollover timer wakes; `enterDeepSleep()` uses `min(rollover, health-check)`; `enterExtendedDeepSleep()` adds timer alongside tap wake; `setup()` handles health-check wakes (normal boot, auto-sleep after 30s)
- **`activity_stats.cpp`** — Health-check wakes use `activityStatsRecordWakeStart(WAKE_REASON_TIMER)` for iOS visibility; backpack session timer counter incremented on timer wakes
- **`PRD.md`** — Documented health-check wake trigger and updated backpack mode description

## Test results

- ✅ Normal sleep health-check timer confirmed: `"Sleep timer set: 7200 seconds (health check)"`
- ✅ Health-check timer wake from normal sleep confirmed: `"Woke up from timer (health check)"`
- ✅ Device boots normally on health-check wake, auto-sleeps after 30s inactivity
- ✅ Activity stats properly recorded (reason=1 = WAKE_REASON_TIMER)
- ✅ `HEALTH_CHECK_WAKE_INTERVAL_SEC` restored to 7200 for production

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)