### PR TITLE
Remove redundant single-tap wake interrupt

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-02-08 (Session 34)
+**Last Updated:** 2026-02-08 (Session 35)
 **Current Branch:** `master`
 
 ---
@@ -13,23 +13,12 @@ None — ready for next task.
 
 ## Recently Completed
 
+- **Remove Redundant Single-Tap Wake Interrupt** - [Plan 072](Plans/072-remove-redundant-single-tap-wake.md) ✅ COMPLETE — Single-tap wake interrupt was redundant with activity wake in normal deep sleep (activity 1.5g < tap 3.0g). Removed single-tap from INT_ENABLE (0x70→0x30), kept activity + double-tap. Changed backpack wake screen text from "waking" to "waking up". PRD updated.
 - **Simplify Boot/Wake Serial Log Output (Issue #108)** - [Plan 071](Plans/071-simplify-boot-wake-serial-log.md) ✅ COMPLETE — Reduced boot/wake serial output from ~90 lines to ~20 lines. Wrapped verbose messages in DEBUG_PRINTF across 7 files (main.cpp, config.h, storage.cpp, display.cpp, drinks.cpp, activity_stats.cpp, storage_drinks.cpp). Separated gesture+countdown status line (unconditional, every 3s) from accel debug (d4+). Enabled serial commands in IOS_MODE (both BLE + serial fit in IRAM with ~9.7KB headroom). Fixed display.cpp DEBUG_PRINTF(1,...) bug. All debug category defaults set to 0; `d0`-`d9` runtime control available.
 - **Fix: False wakes from table nudges (Issue #110)** - [Plan 070](Plans/070-reduce-single-tap-sensitivity.md) ✅ COMPLETE — Table nudges triggered false wakes from normal sleep. Root cause was activity interrupt threshold (0.5g), not single-tap. Fix: increased `ACTIVITY_WAKE_THRESHOLD` from 0x08 (0.5g) to 0x18 (1.5g). Tap threshold unchanged. PRD updated.
-- **Fix: Auto-recovery after battery depletion (Issue #107)** - [Plan 069](Plans/069-battery-depletion-recovery.md) ✅ COMPLETE — ESP32 could get stuck in deep sleep after battery depletion because ADXL343 loses interrupt config while ESP32 RTC domain persists. Fix: periodic health-check timer wake (every 2 hours) added to both normal and extended deep sleep modes. Device boots normally on health-check wake, auto-sleeps after 30s. Battery impact ~1mAh/day. PRD updated.
-- **Fix False Double-Tap Triggering Backpack Mode (Issue #103)** - [Plan 068](Plans/068-false-double-tap-backpack-fix.md) ✅ COMPLETE — Setting bottle down on hard surface created bounce pattern matching ADXL343 double-tap, falsely entering backpack mode. Fix: gate double-tap handler on `g_has_been_upright_stable` flag — bottle must have settled on surface (2s stability) before double-tap can trigger backpack mode. ~5 lines changed.
-- **Fix Backpack Mode Entry (Issue #97)** - [Plan 067](Plans/067-backpack-mode-entry-fix.md) ✅ COMPLETE — Backpack mode never entered when bottle horizontal. Root cause: per-cycle flags/counters couldn't track state across 30s wake/sleep cycles. Fix: check current gesture (`gesture != GESTURE_UPRIGHT_STABLE`) at sleep time — if not on surface, stay awake and let 180s backpack timer handle it. Four approaches tried; final solution is zero new state, net -1 line.
-- **Fix ADXL343 Register Addresses (Issue #98)** - [Plan 066](Plans/066-fix-adxl343-register-addresses.md) ✅ COMPLETE — Fixed THRESH_ACT register (0x1C → 0x24), separated activity threshold (0.5g) from tap threshold (3.0g), updated PRD.
-- **Double-Tap to Enter Backpack Mode (Issue #99)** - [Plan 065](Plans/065-double-tap-to-sleep.md) ✅ COMPLETE — Double-tap gesture to manually enter extended deep sleep. ADXL343 hardware detection, same 3.0g threshold as wake. PRD updated.
-- **Import/Export Backup (Issue #93)** - [Plan 064](Plans/064-import-export.md) ✅ COMPLETE — JSON backup export/import with Merge and Replace modes. New "Data" category in Settings. iOS-UX-PRD updated.
-- **Display Redraw on Wake Fix (Issue #88)** - [Plan 063](Plans/063-display-redraw-on-wake.md) ✅ COMPLETE — Persisted daily goal in RTC memory, removed dual flag check in displayNeedsUpdate().
-- **Settings Page Redesign (Issue #87)** - Plan 063 ✅ COMPLETE (PR #89) — Option 5 (Smart Contextual sub-pages) selected. Keep-alive fix, Health/Notification status flags, error message cleanup. iOS-UX-PRD updated.
-- **Daily Goal Setting from iOS App (Issue #83)** - [Plan 062](Plans/062-daily-goal-setting.md) ✅ COMPLETE (PR #86)
-- **Calibration Circular Dependency Fix (Issue #84)** - [Plan 062](Plans/062-calibration-circular-dependency.md) ✅ COMPLETE (PR #85)
-- **Faded Blue Behind Indicator (Issue #81)** - [Plan 061](Plans/061-faded-blue-behind-indicator.md) ✅ COMPLETE
-- **iOS Calibration Flow (Issue #30)** - [Plan 060](Plans/060-ios-calibration-flow.md) ✅ COMPLETE
-- **LittleFS Drink Storage / NVS Fragmentation Fix (Issue #76)** - [Plan 059](Plans/059-littlefs-drink-storage.md)
-- Drink Baseline Hysteresis Fix (Issue #76) - [Plan 057](Plans/057-drink-baseline-hysteresis.md)
-- Unified Sessions View Fix (Issue #74) - [Plan 056](Plans/056-unified-sessions-view.md)
+- **Fix: Auto-recovery after battery depletion (Issue #107)** - [Plan 069](Plans/069-battery-depletion-recovery.md) ✅ COMPLETE
+- **Fix False Double-Tap Triggering Backpack Mode (Issue #103)** - [Plan 068](Plans/068-false-double-tap-backpack-fix.md) ✅ COMPLETE
+- **Fix Backpack Mode Entry (Issue #97)** - [Plan 067](Plans/067-backpack-mode-entry-fix.md) ✅ COMPLETE
 
 ---
 
@@ -37,7 +26,7 @@ None — ready for next task.
 
 To resume from this progress file:
 ```
-Resume from PROGRESS.md — no active task. Issue #108 complete on branch simplify-boot-wake-serial-log (PR pending merge). Serial commands now enabled alongside BLE in IOS_MODE.
+Resume from PROGRESS.md — no active task. Plan 072 complete on branch remove-redundant-single-tap-wake (PR pending merge).
 ```
 
 ---

--- a/Plans/072-remove-redundant-single-tap-wake.md
+++ b/Plans/072-remove-redundant-single-tap-wake.md
@@ -1,0 +1,33 @@
+# Remove Redundant Single-Tap Wake Interrupt
+
+## Context
+
+When the bottle wakes from normal deep sleep via a single tap, the serial log shows it as an activity wake ("Woke up from EXT0 (tilt/motion interrupt!)"). This is because the activity threshold (1.5g) is lower than the single-tap threshold (3.0g), so any tap that triggers single-tap also triggers activity. Since both interrupts share the same INT1 pin and the ESP32 can't distinguish them, single-tap wake adds no value during normal deep sleep.
+
+Double-tap remains essential: it's polled via INT_SOURCE while awake (manual backpack mode entry) and is the sole wake source in extended/backpack sleep.
+
+## Changes
+
+### 1. Remove single-tap from normal sleep interrupt config
+**File:** [main.cpp](firmware/src/main.cpp)
+
+In `configureADXL343Interrupt()` (~line 298):
+- Change `INT_ENABLE` from `0x70` (activity + single-tap + double-tap) to `0x30` (activity + double-tap)
+- Update the comments at lines 293-298 and debug messages at lines 299, 310
+- Remove or update the "Step 5" comment block (lines 274-278) that describes single-tap as an "additional wake method" - the tap threshold/duration config still applies to double-tap so the register writes stay, just update the comments
+- Update the summary log at line 314
+
+### 2. Update config.h comment
+**File:** [config.h](firmware/src/config.h)
+
+- Line 147: Change comment from "shared by single-tap wake + double-tap backpack mode" to just "double-tap detection (backpack mode)"
+
+## What stays unchanged
+- All tap threshold/duration/window/latency register writes (needed for double-tap detection)
+- `configureADXL343TapWake()` (backpack mode - only enables double-tap, already correct)
+- Double-tap polling in gesture detection loop (INT_SOURCE bit 5)
+- All extended sleep / backpack mode logic
+
+## Verification
+- Build firmware: `cd firmware && ~/.platformio/penv/bin/platformio run`
+- Upload and test: single tap still wakes bottle (via activity interrupt); double-tap while awake still enters backpack mode; double-tap wakes from extended sleep

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -142,8 +142,7 @@ After cutting, verify LED no longer illuminates when board is powered.
 ### 2. Measurement Logic
 
 #### Wake Triggers
-- **Single-tap wake (normal sleep):** ADXL343 single-tap interrupt (>3.0g threshold, <10ms duration) - firm tap wakes device
-- **Motion wake (normal sleep):** ADXL343 activity interrupt (>1.5g threshold, AC-coupled) - tilt or pick-up wakes device
+- **Motion wake (normal sleep):** ADXL343 activity interrupt (>1.5g threshold, AC-coupled) - tilt, pick-up, or tap wakes device. A single tap exceeds the 1.5g activity threshold so a dedicated single-tap interrupt is not needed.
 - **Rollover wake:** Timer-based wake at midnight daily reset to refresh display with 0ml daily total
   - Ensures display shows correct daily total even if bottle sleeps through rollover
   - Returns to sleep immediately after display refresh (no BLE advertising)

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -144,7 +144,7 @@ extern uint8_t g_daily_intake_display_mode;
 // Activity detection for normal sleep wake (ADXL343 AC-coupled activity interrupt)
 #define ACTIVITY_WAKE_THRESHOLD     0x18    // 1.5g threshold (24 x 62.5mg/LSB) - detects tilt to pour
 
-// Tap detection threshold (shared by single-tap wake + double-tap backpack mode)
+// Tap detection threshold (double-tap detection for backpack mode)
 #define TAP_WAKE_THRESHOLD          0x30    // 3.0g threshold (48 x 62.5mg/LSB) - firm tap required
 #define TAP_WAKE_DURATION           0x10    // 10ms max duration (16 x 625us/LSB) - short sharp tap
 #define TAP_WAKE_LATENT             0x50    // 100ms latency (80 x 1.25ms/LSB) - between taps

--- a/firmware/src/display.cpp
+++ b/firmware/src/display.cpp
@@ -737,7 +737,7 @@ void displayTapWakeFeedback() {
 
     // "waking" in large text
     g_display_ptr->setTextSize(3);
-    const char* text = "waking";
+    const char* text = "waking up";
     int text_width = strlen(text) * 18;  // 18px per char at textSize=3
     int text_x = (250 - text_width) / 2;
     g_display_ptr->setCursor(text_x, 40);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -271,8 +271,7 @@ void configureADXL343Interrupt() {
     writeAccelReg(ACT_INACT_CTL, 0xF0);     // All axes activity enable (AC-coupled)
     DEBUG_PRINTLN(g_debug_accelerometer, "4. Activity axes: X, Y, Z (AC-coupled)");
 
-    // Step 5: Configure single-tap detection (additional wake method)
-    // Tap threshold: 3.0g (same as double-tap in backpack mode)
+    // Step 5: Configure tap threshold (used by double-tap detection for backpack mode)
     // Scale = 62.5 mg/LSB, 3.0g = 48 (0x30)
     writeAccelReg(THRESH_TAP, TAP_WAKE_THRESHOLD);
     DEBUG_PRINTF(g_debug_accelerometer, "5. Tap threshold: 0x%02X (%.1fg)\n", TAP_WAKE_THRESHOLD, TAP_WAKE_THRESHOLD * 0.0625f);
@@ -290,13 +289,12 @@ void configureADXL343Interrupt() {
     writeAccelReg(POWER_CTL, 0x08);         // Measurement mode (bit 3)
     DEBUG_PRINTLN(g_debug_accelerometer, "8. Power mode: measurement");
 
-    // Step 9: Enable activity + single-tap + double-tap interrupts
-    // Bit 4 = Activity (0x10)
-    // Bit 5 = Double-tap (0x20)
-    // Bit 6 = Single-tap (0x40)
-    // Combined = 0x70
-    writeAccelReg(INT_ENABLE, 0x70);        // Activity + single-tap + double-tap interrupts
-    DEBUG_PRINTLN(g_debug_accelerometer, "9. Interrupt enable: activity + single-tap + double-tap");
+    // Step 9: Enable activity + double-tap interrupts
+    // Bit 4 = Activity (0x10) - wake from normal sleep
+    // Bit 5 = Double-tap (0x20) - manual backpack mode entry while awake
+    // Note: Single-tap (0x40) removed - redundant with activity (1.5g < 3.0g tap threshold)
+    writeAccelReg(INT_ENABLE, 0x30);        // Activity + double-tap interrupts
+    DEBUG_PRINTLN(g_debug_accelerometer, "9. Interrupt enable: activity + double-tap");
 
     // Step 10: Route all interrupts to INT1 pin
     writeAccelReg(INT_MAP, 0x00);           // All interrupts to INT1
@@ -307,11 +305,11 @@ void configureADXL343Interrupt() {
     DEBUG_PRINTF(g_debug_accelerometer, "11. Cleared INT_SOURCE: 0x%02X\n", int_source);
 
     DEBUG_PRINTLN(g_debug_accelerometer, "\n=== Configuration Complete ===");
-    DEBUG_PRINTF(g_debug_accelerometer, "Sleep wake: Single-tap (>%.1fg) OR activity (>%.1fg)\n", TAP_WAKE_THRESHOLD * 0.0625f, ACTIVITY_WAKE_THRESHOLD * 0.0625f);
+    DEBUG_PRINTF(g_debug_accelerometer, "Sleep wake: Activity (>%.1fg)\n", ACTIVITY_WAKE_THRESHOLD * 0.0625f);
     DEBUG_PRINTLN(g_debug_accelerometer, "Awake: Double-tap detected via INT_SOURCE polling\n");
 
     // Unconditional one-line summary
-    Serial.printf("ADXL343: Interrupts configured (activity >%.1fg, tap >%.1fg)\n",
+    Serial.printf("ADXL343: Interrupts configured (activity >%.1fg, double-tap >%.1fg)\n",
                   ACTIVITY_WAKE_THRESHOLD * 0.0625f, TAP_WAKE_THRESHOLD * 0.0625f);
 }
 


### PR DESCRIPTION
## Summary
- Removed single-tap interrupt from normal sleep wake config (`INT_ENABLE` 0x70 → 0x30) — redundant since activity threshold (1.5g) is lower than tap threshold (3.0g), so any tap already triggers activity wake
- Double-tap retained for backpack mode entry/wake
- Changed backpack wake screen text from "waking" to "waking up"
- PRD updated to document that taps are covered by the activity interrupt

See [Plan 072](Plans/072-remove-redundant-single-tap-wake.md) for full details.

## Test plan
- [ ] Firmware builds cleanly (verified)
- [ ] Single tap still wakes bottle from normal sleep (via activity interrupt)
- [ ] Double-tap while awake still enters backpack mode
- [ ] Double-tap wakes from extended/backpack sleep
- [ ] Boot log shows `ADXL343: Interrupts configured (activity >1.5g, double-tap >3.0g)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)