### PR TITLE
Fix: drink not detected when bottle emptied (Issue #116)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-02-08 (Session 36)
+**Last Updated:** 2026-02-08 (Session 37)
 **Current Branch:** `master`
 
 ---
@@ -13,6 +13,7 @@ None — ready for next task.
 
 ## Recently Completed
 
+- **Fix: Drink not detected when bottle is emptied (Issue #116)** - [Plan 074](Plans/074-ble-set-time-baseline-fix.md) ✅ COMPLETE — BLE SET_TIME handler was calling `drinksInit()` on every connection, zeroing the drink detection baseline. If this happened while holding the bottle, the drink was invisible. Fix: added `drinksIsInitialized()` guard, removed forced baseline zero in `drinksInit()`, moved RTC restore before wakeup guard (survives EN-pin resets), added NVS save in `drinksSaveToRTC()` for better power-cycle fallback. Also excluded SET_TIME from activity timeout reset (was adding 30s unnecessary awake time). 4 firmware files changed.
 - **Foreground Auto-Reconnection to Bottle (Issue #114)** - [Plan 073](Plans/073-foreground-auto-reconnection.md) ✅ COMPLETE — Used `CBCentralManager.connect()` in foreground (same as background) so app auto-connects when bottle advertises without manual pull-to-refresh. Renamed all "background reconnect" APIs to "auto-reconnect". Single file change: BLEManager.swift. PRD and IOS-UX-PRD updated.
 - **Remove Redundant Single-Tap Wake Interrupt** - [Plan 072](Plans/072-remove-redundant-single-tap-wake.md) ✅ COMPLETE — Single-tap wake interrupt was redundant with activity wake in normal deep sleep (activity 1.5g < tap 3.0g). Removed single-tap from INT_ENABLE (0x70→0x30), kept activity + double-tap. Changed backpack wake screen text from "waking" to "waking up". PRD updated.
 - **Simplify Boot/Wake Serial Log Output (Issue #108)** - [Plan 071](Plans/071-simplify-boot-wake-serial-log.md) ✅ COMPLETE — Reduced boot/wake serial output from ~90 lines to ~20 lines. Wrapped verbose messages in DEBUG_PRINTF across 7 files (main.cpp, config.h, storage.cpp, display.cpp, drinks.cpp, activity_stats.cpp, storage_drinks.cpp). Separated gesture+countdown status line (unconditional, every 3s) from accel debug (d4+). Enabled serial commands in IOS_MODE (both BLE + serial fit in IRAM with ~9.7KB headroom). Fixed display.cpp DEBUG_PRINTF(1,...) bug. All debug category defaults set to 0; `d0`-`d9` runtime control available.
@@ -27,7 +28,7 @@ None — ready for next task.
 
 To resume from this progress file:
 ```
-Resume from PROGRESS.md — no active task. Ready for next task on master branch.
+Resume from PROGRESS.md — no active task. Read PROGRESS.md for recently completed work.
 ```
 
 ---

--- a/Plans/074-ble-set-time-baseline-fix.md
+++ b/Plans/074-ble-set-time-baseline-fix.md
@@ -1,0 +1,65 @@
+# Plan: Fix Drink Detection Baseline Loss from BLE SET_TIME
+
+## Context
+
+When pouring ~150ml from a bottle until empty, the drink was not detected. Logs showed:
+```
+Drinks: baseline=-4.3ml, current=-4.4ml, delta=0.1ml
+[BLE] Battery level updated: 100%
+```
+
+The baseline was at "empty" (-4.3ml) when it should have been at ~150ml.
+
+**Root cause:** When the iOS app connects via BLE and sends a `SET_TIME` command, the BLE handler at [ble_service.cpp:197](firmware/src/ble_service.cpp#L197) calls `drinksInit()`. This **zeros the baseline** (`last_recorded_adc = 0` at [drinks.cpp:170](firmware/src/drinks.cpp#L170)). If this happens while the user is holding the bottle (between pickup and putdown), the RTC-restored baseline is destroyed. The next `drinksUpdate()` — which only runs during `UPRIGHT_STABLE` — establishes a fresh baseline from the current (post-drink) reading. The drink is invisible.
+
+**Why it's intermittent:** The SET_TIME command usually arrives while the bottle is sitting on the sensor, so the baseline gets re-established at the correct water level before the next drink. The failure only occurs when the timing is unlucky: user picks up bottle → wake → iOS connects and sends SET_TIME (resetting baseline) → user drinks → puts bottle down → baseline established at empty → drink missed.
+
+## Changes
+
+### 1. Guard `drinksInit()` call in BLE SET_TIME handler — [ble_service.cpp:197](firmware/src/ble_service.cpp#L197)
+
+Only call `drinksInit()` if drink tracking is not already initialized. This is the primary fix. The BLE handler should use `drinksInit()` for the first-time initialization case (when time wasn't valid before), not as a re-init on every SET_TIME.
+
+Add a `bool drinksIsInitialized()` function to [drinks.h](firmware/include/drinks.h) / [drinks.cpp](firmware/src/drinks.cpp) that returns `g_drinks_initialized`. Then in the BLE handler:
+```cpp
+if (!drinksIsInitialized()) {
+    drinksInit();
+}
+```
+
+### 2. Remove forced baseline reset in `drinksInit()` — [drinks.cpp:167-170](firmware/src/drinks.cpp#L167-L170)
+
+Defence-in-depth: Remove `g_daily_state.last_recorded_adc = 0` (line 170). Let the NVS-loaded value persist as a fallback. The validation in `drinksUpdate()` (lines 210-217) catches corrupt baselines (< -100ml or > 1000ml). First-boot-ever is unchanged (NVS load fails → memset zeros state → baseline = 0 → established from first reading).
+
+This also protects against the same issue in [serial_commands.cpp](firmware/src/serial_commands.cpp) (lines 234, 362, 448) which also calls `drinksInit()`.
+
+### 3. Try RTC restore on ALL boot types — [main.cpp:~1014](firmware/src/main.cpp#L1014)
+
+Move `drinksRestoreFromRTC()` call **before** the wakeup reason guard at line 1015. RTC memory survives EN-pin resets (serial monitor connect). The magic number check inside `drinksRestoreFromRTC()` already handles power-on resets (RTC cleared → magic = 0 → returns false, NVS fallback used from Change 2).
+
+### 4. Save daily state to NVS inside `drinksSaveToRTC()` — [drinks.cpp:430](firmware/src/drinks.cpp#L430)
+
+Add `storageSaveDailyState(g_daily_state)` inside `drinksSaveToRTC()`. Since both sleep functions already call `drinksSaveToRTC()`, this keeps the NVS baseline up-to-date with the latest drift-compensated value before every sleep. Makes the NVS a better fallback for power-on resets.
+
+### 5. Add diagnostic logging
+
+- In `drinksInit()`: unconditional log showing NVS-loaded baseline ADC
+- In `main.cpp`: log whether RTC restore succeeded and the baseline value
+- In `drinksUpdate()` (line 221): make baseline establishment log unconditional (currently debug-gated)
+- In BLE SET_TIME handler: log whether drinksInit was called or skipped
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| [firmware/src/drinks.cpp](firmware/src/drinks.cpp) | Remove baseline reset (line 170), add `drinksIsInitialized()`, add NVS save in `drinksSaveToRTC()`, add logging |
+| [firmware/include/drinks.h](firmware/include/drinks.h) | Declare `drinksIsInitialized()` |
+| [firmware/src/ble_service.cpp](firmware/src/ble_service.cpp) | Guard `drinksInit()` call with `drinksIsInitialized()` check |
+| [firmware/src/main.cpp](firmware/src/main.cpp) | Move `drinksRestoreFromRTC()` outside wakeup guard, add logging |
+
+## Verification
+
+1. **Build**: `cd firmware && ~/.platformio/penv/bin/platformio run`
+2. **Manual test — drink to empty**: Fill bottle, pick up, drink until empty, put down. Verify drink IS detected on display.
+3. **Check logs**: Verify "Drinks: Init baseline" shows NVS value, "Drinks: Baseline restored from RTC" appears on wake, and BLE SET_TIME logs "skipped drinksInit (already initialized)"
+4. **Normal drink detection**: Verify partial drinks still register correctly

--- a/firmware/include/drinks.h
+++ b/firmware/include/drinks.h
@@ -37,6 +37,12 @@ struct DailyState {
 void drinksInit();
 
 /**
+ * Check if drink tracking is already initialized
+ * Used to avoid redundant re-initialization (e.g., BLE SET_TIME)
+ */
+bool drinksIsInitialized();
+
+/**
  * Update drink tracking (call every 2 seconds when bottle is stable)
  * Detects drink events, manages aggregation, triggers display updates
  *


### PR DESCRIPTION
## Summary
- **Root cause:** BLE `SET_TIME` handler called `drinksInit()` on every iOS connection, zeroing the drink detection baseline. If this happened while user was holding the bottle, the drink became invisible.
- **Fix:** Guard `drinksInit()` with `drinksIsInitialized()` check; remove forced baseline zero; move RTC restore before wakeup guard; save baseline to NVS before every sleep for better power-cycle fallback.
- **Bonus:** Excluded `SET_TIME` from BLE activity timeout reset (was adding ~30s unnecessary awake time per connection).

See [Plan 074](Plans/074-ble-set-time-baseline-fix.md) for full analysis.

## Files changed
- `firmware/src/drinks.cpp` — removed baseline reset, added `drinksIsInitialized()`, NVS save in `drinksSaveToRTC()`, unconditional diagnostic logging
- `firmware/include/drinks.h` — declared `drinksIsInitialized()`
- `firmware/src/ble_service.cpp` — guarded `drinksInit()` call, excluded SET_TIME from activity timeout
- `firmware/src/main.cpp` — moved `drinksRestoreFromRTC()` before wakeup guard

## Test plan
- [x] Firmware builds successfully (IRAM 94.0%, ~7.9KB headroom)
- [x] Fill bottle, pick up, drink until empty, put down — drink appears on display
- [x] Serial logs show `"skipped drinksInit"` on SET_TIME when already initialized
- [x] Serial logs show `"Baseline restored from RTC"` on wake from sleep
- [x] SET_TIME no longer resets the activity sleep countdown
- [x] Normal partial drink detection still works correctly
- [x] Cold boot (power cycle) re-establishes baseline from first stable reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)