### PR TITLE
feat: low battery lockout with two-tier warning (Issue #68)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,18 +1,29 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-02-08 (Session 37)
+**Last Updated:** 2026-02-08 (Session 38)
 **Current Branch:** `master`
+**GitHub Issue:** None
 
 ---
 
 ## Current Task
 
-None — ready for next task.
+No active task. Ready for next issue.
+
+---
+
+## Context Recovery
+
+To resume from this progress file:
+```
+Resume from PROGRESS.md — no active task. Low Battery Lockout (Issue #68) was just completed and merged.
+```
 
 ---
 
 ## Recently Completed
 
+- **Low Battery Lockout (Issue #68)** - [Plan 075](Plans/075-low-battery-lockout.md) ✅ COMPLETE — Two-tier battery warning: iOS early warning at 25% (BLE flag + push notification + red badge), firmware lockout at 20% (full-screen "charge me", timer-only deep sleep with 15-min health checks). Recovery at 25% with hysteresis. Threshold runtime-configurable via `SET BATTERY LOCKOUT THRESHOLD` serial command, persisted in NVS. 9 firmware files + 4 iOS files changed. PRD and IOS-UX-PRD updated.
 - **Fix: Drink not detected when bottle is emptied (Issue #116)** - [Plan 074](Plans/074-ble-set-time-baseline-fix.md) ✅ COMPLETE — BLE SET_TIME handler was calling `drinksInit()` on every connection, zeroing the drink detection baseline. If this happened while holding the bottle, the drink was invisible. Fix: added `drinksIsInitialized()` guard, removed forced baseline zero in `drinksInit()`, moved RTC restore before wakeup guard (survives EN-pin resets), added NVS save in `drinksSaveToRTC()` for better power-cycle fallback. Also excluded SET_TIME from activity timeout reset (was adding 30s unnecessary awake time). 4 firmware files changed.
 - **Foreground Auto-Reconnection to Bottle (Issue #114)** - [Plan 073](Plans/073-foreground-auto-reconnection.md) ✅ COMPLETE — Used `CBCentralManager.connect()` in foreground (same as background) so app auto-connects when bottle advertises without manual pull-to-refresh. Renamed all "background reconnect" APIs to "auto-reconnect". Single file change: BLEManager.swift. PRD and IOS-UX-PRD updated.
 - **Remove Redundant Single-Tap Wake Interrupt** - [Plan 072](Plans/072-remove-redundant-single-tap-wake.md) ✅ COMPLETE — Single-tap wake interrupt was redundant with activity wake in normal deep sleep (activity 1.5g < tap 3.0g). Removed single-tap from INT_ENABLE (0x70→0x30), kept activity + double-tap. Changed backpack wake screen text from "waking" to "waking up". PRD updated.
@@ -21,15 +32,6 @@ None — ready for next task.
 - **Fix: Auto-recovery after battery depletion (Issue #107)** - [Plan 069](Plans/069-battery-depletion-recovery.md) ✅ COMPLETE
 - **Fix False Double-Tap Triggering Backpack Mode (Issue #103)** - [Plan 068](Plans/068-false-double-tap-backpack-fix.md) ✅ COMPLETE
 - **Fix Backpack Mode Entry (Issue #97)** - [Plan 067](Plans/067-backpack-mode-entry-fix.md) ✅ COMPLETE
-
----
-
-## Context Recovery
-
-To resume from this progress file:
-```
-Resume from PROGRESS.md — no active task. Read PROGRESS.md for recently completed work.
-```
 
 ---
 

--- a/Plans/075-low-battery-lockout.md
+++ b/Plans/075-low-battery-lockout.md
@@ -1,0 +1,150 @@
+# Plan: Low Battery Lockout (Issue #68) ✅ COMPLETE
+
+## Context
+
+The Aquavate bottle currently has no proactive low battery notification. Users can be caught off-guard when the bottle stops working due to a depleted battery. This feature adds:
+1. **iOS early warning**: The iOS app warns the user (push notification + in-app banner) when battery drops below the *warning* level (lockout + 5%). The bottle is still functional at this point, giving the user advance notice.
+2. **Firmware lockout**: A full-screen "charge me" icon on the e-paper display when battery drops below the *lockout* threshold. The bottle becomes unusable until charged above the recovery level.
+3. The threshold is runtime-configurable via serial command (85% for testing, 20% for production), persisted in NVS.
+
+## Two-Tier Battery Warning System
+
+| Level | Default | Trigger | What happens |
+|-------|---------|---------|-------------|
+| **Warning** | 25% (lockout + 5%) | Battery < warning level | BLE flag set → iOS app shows banner + push notification. Bottle still works normally. |
+| **Lockout** | 20% | Battery < lockout level | Full-screen "charge me" on e-paper. No drink detection, no BLE. Timer-only deep sleep. |
+| **Recovery** | 25% (= warning level) | Battery >= recovery level | Lockout clears, normal operation resumes. |
+
+The warning and recovery thresholds are the same value (lockout + offset), which is elegant: the iOS warns while the bottle works, then the firmware locks out, and recovery clears both.
+
+## Design Decisions
+
+- **Hysteresis**: Lock at threshold (default 20%), recover at threshold + 5% (default 25%). Prevents oscillation near the boundary. The 5% offset is a compile-time constant.
+- **iOS warns early**: The BLE `LOW_BATTERY` flag is set when battery < (lockout + offset), i.e., at 25%. This fires while the bottle is still operational, so the iOS app reliably sees it during normal background auto-reconnection.
+- **No BLE during lockout**: The bottle does NOT advertise during lockout sleep, to conserve remaining battery. By the time lockout triggers, the iOS app has already warned the user during the warning phase.
+- **Timer-only sleep during lockout**: No motion wake (saves power). Health check wakes every **15 minutes** during lockout (vs 2 hours normally) so recovery is detected quickly after charging. The power cost is negligible (~0.03mAh per check).
+- **RTC + NVS for threshold**: NVS stores the threshold persistently. An RTC variable caches it for fast access during the early lockout check in setup(). `storageInit()` is called early (it's idempotent) to load the threshold before the lockout check.
+
+## Files to Modify
+
+### Firmware
+
+#### 1. `firmware/include/config.h` — Add threshold constants
+After the Battery Voltage section (~line 184):
+```cpp
+// Low Battery Lockout
+#define LOW_BATTERY_LOCKOUT_PCT_DEFAULT  20      // Default lockout threshold (%)
+#define LOW_BATTERY_RECOVERY_OFFSET      5       // Recovery = lockout + this (%)
+#define LOW_BATTERY_CHECK_INTERVAL_SEC   900     // 15 minutes between checks during lockout
+```
+
+#### 2. `firmware/include/storage.h` — Add storage function declarations
+```cpp
+bool storageSaveLowBatteryThreshold(uint8_t percent);
+uint8_t storageLoadLowBatteryThreshold();
+```
+
+#### 3. `firmware/src/storage.cpp` — Add NVS key and functions
+Add key: `static const char* KEY_LOW_BAT_THR = "low_bat_thr";`
+
+Add save/load functions following the existing pattern (e.g., `storageSaveDisplayMode`/`storageLoadDisplayMode`). Default return value: `LOW_BATTERY_LOCKOUT_PCT_DEFAULT`.
+
+#### 4. `firmware/include/display.h` — Add function declaration
+```cpp
+void displayLowBattery();
+```
+
+#### 5. `firmware/src/display.cpp` — Add full-screen low battery display
+New `displayLowBattery()` function following the pattern of `displayBackpackMode()` (line 694):
+- `clearBuffer()` → draw large battery outline (80x40px, thick border) centered on display
+- Exclamation mark "!" inside the battery (textSize=3)
+- Battery terminal nub on right side
+- "charge me" text below (textSize=3, centered)
+- "battery too low to operate" note at bottom (textSize=1)
+- `display()` to refresh
+
+#### 6. `firmware/src/main.cpp` — Core lockout logic
+
+**RTC variables** (after existing RTC declarations, ~line 75):
+```cpp
+RTC_DATA_ATTR bool rtc_low_battery_lockout = false;
+RTC_DATA_ATTR uint8_t rtc_low_battery_threshold = LOW_BATTERY_LOCKOUT_PCT_DEFAULT;
+```
+
+**Early lockout check in setup()** — after battery read (line 745) and before sensor init:
+1. Call `storageInit()` early (idempotent — safe to call again at line 818)
+2. Load threshold from NVS into `rtc_low_battery_threshold`
+3. Calculate recovery threshold = `rtc_low_battery_threshold + LOW_BATTERY_RECOVERY_OFFSET`
+4. If `rtc_low_battery_lockout` is true:
+   - If battery >= recovery threshold → clear lockout, log recovery, continue normal boot
+   - If still below → call `displayInit(display)` + `displayLowBattery()`, enter timer-only deep sleep (LOW_BATTERY_CHECK_INTERVAL_SEC)
+5. If `rtc_low_battery_lockout` is false:
+   - If battery < lockout threshold → set lockout flag, show battery screen, enter timer-only deep sleep (LOW_BATTERY_CHECK_INTERVAL_SEC)
+
+**Loop lockout check** — after the existing battery read in the display update section (~line 1780):
+- If battery < lockout threshold and not already in lockout → set flag, show battery screen, stop BLE, save state to RTC, enter timer-only deep sleep (LOW_BATTERY_CHECK_INTERVAL_SEC)
+
+#### 7. `firmware/include/ble_service.h` — Add low battery flag
+```cpp
+#define BLE_FLAG_LOW_BATTERY  0x20  // Bit 5: Battery below warning threshold (lockout + offset)
+```
+Update the `flags` field comment in `BLE_CurrentState` to include Bit 5.
+
+#### 8. `firmware/src/ble_service.cpp` — Set flag in Current State
+In `bleUpdateCurrentState()`: if `battery_percent < (rtc_low_battery_threshold + LOW_BATTERY_RECOVERY_OFFSET)`, set `BLE_FLAG_LOW_BATTERY` in flags. This triggers at the WARNING level (25%), not the lockout level (20%), giving the iOS app advance notice while the bottle is still operational. Add change detection for this flag to trigger notification to iOS.
+
+#### 9. `firmware/src/serial_commands.cpp` — Add serial commands
+- `SET LOW BATTERY LOCKOUT <percent>` — validates 5-95%, saves to NVS, updates `rtc_low_battery_threshold`
+- `GET LOW BATTERY` — shows current lockout threshold, recovery threshold, and lockout state
+- Add lockout info to `GET STATUS` output
+- Update help text
+
+### iOS App
+
+#### 10. `ios/Aquavate/Aquavate/Services/BLEStructs.swift` — Parse low battery flag
+Add to `BLECurrentState`:
+```swift
+var isLowBattery: Bool { (flags & 0x20) != 0 }
+```
+
+#### 11. `ios/Aquavate/Aquavate/Services/BLEManager.swift` — Detect and publish
+- Add `@Published private(set) var isLowBattery: Bool = false`
+- In `handleCurrentStateUpdate()`: detect transition to low battery, post `Notification.Name.bottleLowBatteryDetected`
+
+#### 12. `ios/Aquavate/Aquavate/Services/NotificationManager.swift` — Push notification
+Add `scheduleLowBatteryNotification(batteryPercent:)` method using fixed identifier `"bottle-low-battery"` (prevents duplicate notifications). Uses existing UNUserNotificationCenter infrastructure.
+
+#### 13. `ios/Aquavate/Aquavate/Views/HomeView.swift` — In-app warning
+- Add red "Low Battery" status badge when `bleManager.isLowBattery == true`
+- Update `batteryColor` to show red when in lockout
+- Wire up `.onReceive` for the low battery notification to trigger push notification via NotificationManager
+
+## Flow
+
+```
+Normal Operation → Battery drops to 25% (warning level)
+  └─ BLE flag BLE_FLAG_LOW_BATTERY set in Current State
+  └─ iOS app receives notification → shows banner + push notification
+  └─ Bottle continues to work normally
+
+Normal Operation → Battery drops to 20% (lockout level)
+  ├─ Show full-screen "charge me" on e-paper
+  ├─ Set rtc_low_battery_lockout = true
+  └─ Enter timer-only deep sleep (check every 15min, no BLE, no motion wake)
+
+Lockout Check Wake (every 15min) → Read battery
+  ├─ Battery < 25% (recovery): re-display icon → sleep again
+  └─ Battery >= 25% (recovery): clear lockout → normal operation resumes
+
+Power cycle/reset → RTC cleared → fresh battery check → lockout if needed
+```
+
+## Verification
+
+1. **Build firmware**: `cd firmware && ~/.platformio/penv/bin/platformio run` — confirm no IRAM overflow
+2. **Test with threshold=85%**: `SET LOW BATTERY LOCKOUT 85` via serial → bottle should enter lockout immediately on next wake → e-paper shows "charge me" → serial shows lockout messages
+3. **Test persistence**: After health check wake (~2h, or reduce `HEALTH_CHECK_WAKE_INTERVAL_SEC` for testing), serial shows "Still in low battery lockout" and device re-sleeps
+4. **Test recovery**: Connect USB charger → wait for health check wake → battery above 90% → serial shows "Battery recovered" → normal operation resumes
+5. **Test BLE flag**: Connect iOS app while battery is below threshold → app shows red "Low Battery" badge → push notification delivered
+6. **Test serial commands**: `GET LOW BATTERY` shows thresholds and state; `SET LOW BATTERY LOCKOUT 20` restores production threshold
+7. **Build iOS**: `cd ios/Aquavate && xcodebuild -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17' build`

--- a/docs/iOS-UX-PRD.md
+++ b/docs/iOS-UX-PRD.md
@@ -1,10 +1,11 @@
 # Aquavate iOS App - UX Product Requirements Document
 
-**Version:** 1.20
-**Date:** 2026-01-30
-**Status:** Approved (Import/Export)
+**Version:** 1.21
+**Date:** 2026-02-08
+**Status:** Approved (Low Battery Lockout)
 
 **Changelog:**
+- **v1.21 (2026-02-08):** Added low battery warning badge and push notification to HomeView (Issue #68). Red "Low Battery" StatusBadge when BLE flag indicates battery < 25%. Battery icon turns red. Push notification via NotificationManager with fixed identifier (no duplicates). See Section 2.4 and Section 7.
 - **v1.20 (2026-01-30):** Added Data import/export backup to Settings (Issue #93). New "Data" category row on main Settings page with DataSettingsPage sub-page. Export as versioned JSON, import with Merge (skip duplicates) or Replace (clear and restore) modes. ImportPreviewSheet for reviewing backup before import. See Section 2.6.
 - **v1.19 (2026-01-29):** Settings page redesigned with Apple Settings-style sub-pages (Issue #87). Main page shows category rows with contextual summaries; drill-down to Goals & Health, Device Information, Device Controls, Reminder Options. Added BLE keep-alive, Health/Notification status flags. Removed error message display, unused status rows. See Section 2.6.
 - **v1.18 (2026-01-28):** Simplified behind-target indicator to faded blue (Issue #81). Replaced amber/red gradient with 30% opacity blue. Removes visual distinction between urgency levels while keeping deficit text. See Section 2.9.
@@ -376,6 +377,12 @@ Sarah's Bluetooth is accidentally turned off. When she opens the app, she sees a
 | Never connected | Section hidden entirely |
 | Connected | Shows live value (e.g., "56%") |
 | Disconnected with previous data | Shows last known value with "(recent)" suffix (e.g., "56% (recent)") |
+
+**Low Battery Warning (Issue #68):**
+- Red "Low Battery" StatusBadge shown when `bleManager.isLowBattery` (BLE flag bit 5, battery < 25%)
+- Battery icon color changes to red when low battery flag active
+- Push notification triggered on low battery transition via NotificationManager
+- Fixed notification identifier `"bottle-low-battery"` prevents duplicate notifications
 
 **Pull-to-Refresh (Updated 2026-01-18):**
 - If disconnected: Scans and connects to bottle, syncs, stays connected 60s
@@ -1411,7 +1418,7 @@ struct CircularProgressView {
 | 75% | `battery.75` | Green |
 | 50% | `battery.50` | Green |
 | 25% | `battery.25` | Orange |
-| <20% | `battery.25` | Red |
+| <20% (or low battery flag) | `battery.25` | Red |
 | Charging | `battery.100.bolt` | Green |
 
 ---
@@ -1479,7 +1486,7 @@ Deficit = expected - dailyTotalMl
 | Behind pace (overdue) | "Hydration Reminder" | "You're falling behind! Drink Xml to catch up." | iPhone + Watch |
 | Goal achieved | "Goal Reached! 💧" | "Good job! You've hit your daily hydration goal." | iPhone + Watch |
 | Back on track (optional) | "Back On Track! ✓" | "Nice work catching up on your hydration." | iPhone + Watch |
-| Low battery | "Bottle battery low" | "Aquavate at {X}%. Charge soon." | iPhone |
+| Low battery (Issue #68) | "Low Battery" | "Your Aquavate bottle battery is at {X}%. Please charge soon." | iPhone |
 
 **Settings (SettingsView):**
 - Hydration Reminders toggle (main on/off)
@@ -1504,7 +1511,7 @@ Watch notifications include haptic feedback via `WKInterfaceDevice.current().pla
 
 | Trigger | Title | Body | Time | Action |
 |---------|-------|------|------|--------|
-| Low battery | "Bottle battery low" | "Aquavate at {X}%. Charge soon." | When battery < 20% | Open app |
+| Low battery (Issue #68) | "Low Battery" | "Your Aquavate bottle battery is at {X}%. Please charge soon." | BLE flag transition (battery < 25%) | Open app |
 | Sync reminder | "Sync your bottle" | "Haven't synced in 24 hours." | 24h since last sync | Open app |
 
 **Settings:**

--- a/firmware/include/ble_service.h
+++ b/firmware/include/ble_service.h
@@ -47,7 +47,7 @@ struct __attribute__((packed)) BLE_CurrentState {
     uint16_t bottle_level_ml;    // Water level after last event
     uint16_t daily_total_ml;     // Today's cumulative intake
     uint8_t  battery_percent;    // 0-100
-    uint8_t  flags;              // Bit 0: time_valid, Bit 1: calibrated, Bit 2: stable, Bit 3: cal_measuring, Bit 4: cal_result_ready
+    uint8_t  flags;              // Bit 0: time_valid, Bit 1: calibrated, Bit 2: stable, Bit 3: cal_measuring, Bit 4: cal_result_ready, Bit 5: low_battery
     uint16_t unsynced_count;     // Records pending sync
 };
 
@@ -120,6 +120,7 @@ struct __attribute__((packed)) BLE_Command {
 #define BLE_FLAG_STABLE                 0x04  // Bit 2: Weight reading is stable
 #define BLE_FLAG_CAL_MEASURING          0x08  // Bit 3: Calibration measurement in progress
 #define BLE_FLAG_CAL_RESULT_READY       0x10  // Bit 4: Calibration ADC result available
+#define BLE_FLAG_LOW_BATTERY            0x20  // Bit 5: Battery below warning threshold (lockout + offset)
 
 // Device Settings Characteristic (4 bytes)
 struct __attribute__((packed)) BLE_DeviceSettings {

--- a/firmware/include/display.h
+++ b/firmware/include/display.h
@@ -37,6 +37,7 @@ void displayForceUpdate(float water_ml, uint16_t daily_total_ml,
 DisplayState displayGetState();
 void drawMainScreen();
 void displayBackpackMode();      // Show backpack mode screen with wake instructions (Issue #38)
+void displayLowBattery();        // Show full-screen "charge me" lockout screen (Issue #68)
 void displayTapWakeFeedback();   // Show immediate feedback when waking from tap (blank screen)
 void displayNVSWarning();        // Show storage error warning (3 seconds) when NVS write fails
 

--- a/firmware/include/storage.h
+++ b/firmware/include/storage.h
@@ -89,4 +89,10 @@ bool storageSaveDailyGoal(uint16_t goal_ml);
 // Load daily hydration goal from NVS in ml (default: 2500ml)
 uint16_t storageLoadDailyGoal();
 
+// Save low battery lockout threshold to NVS (5-95%)
+bool storageSaveLowBatteryThreshold(uint8_t percent);
+
+// Load low battery lockout threshold from NVS (default: 20%)
+uint8_t storageLoadLowBatteryThreshold();
+
 #endif // STORAGE_H

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -183,6 +183,11 @@ extern uint8_t g_daily_intake_display_mode;
 #define BATTERY_VOLTAGE_FULL    4.2f  // 100%
 #define BATTERY_VOLTAGE_EMPTY   3.2f  // 0%
 
+// Low Battery Lockout
+#define LOW_BATTERY_LOCKOUT_PCT_DEFAULT  20      // Default lockout threshold (%)
+#define LOW_BATTERY_RECOVERY_OFFSET      5       // Recovery = lockout + this (%)
+#define LOW_BATTERY_CHECK_INTERVAL_SEC   900     // 15 minutes between checks during lockout
+
 // ==================== E-Paper Display ====================
 
 #if defined(BOARD_ADAFRUIT_FEATHER)

--- a/firmware/src/display.cpp
+++ b/firmware/src/display.cpp
@@ -727,6 +727,50 @@ void displayBackpackMode() {
     g_display_ptr->display();
 }
 
+// Display full-screen low battery lockout screen (Issue #68)
+void displayLowBattery() {
+    if (g_display_ptr == nullptr) return;
+
+    g_display_ptr->clearBuffer();
+    g_display_ptr->setTextColor(EPD_BLACK);
+
+    // Draw large battery outline centered (80x40px)
+    // Display is 250x122, center at (125, 35)
+    int bx = 85;   // Battery body left
+    int by = 10;    // Battery body top
+    int bw = 80;    // Battery body width
+    int bh = 40;    // Battery body height
+
+    // Battery body outline (thick 3px border)
+    for (int i = 0; i < 3; i++) {
+        g_display_ptr->drawRect(bx + i, by + i, bw - 2*i, bh - 2*i, EPD_BLACK);
+    }
+
+    // Battery terminal nub on right side
+    g_display_ptr->fillRect(bx + bw, by + 12, 6, 16, EPD_BLACK);
+
+    // Exclamation mark "!" inside battery (textSize=3)
+    g_display_ptr->setTextSize(3);
+    g_display_ptr->setCursor(bx + 31, by + 9);
+    g_display_ptr->print("!");
+
+    // "charge me" text below battery (textSize=3, centered)
+    g_display_ptr->setTextSize(3);
+    const char* title = "charge me";
+    int title_width = strlen(title) * 18;  // 18px per char at textSize=3
+    g_display_ptr->setCursor((250 - title_width) / 2, 60);
+    g_display_ptr->print(title);
+
+    // "battery too low to operate" note at bottom (textSize=1)
+    g_display_ptr->setTextSize(1);
+    const char* note = "battery too low to operate";
+    int note_width = strlen(note) * 6;  // 6px per char at textSize=1
+    g_display_ptr->setCursor((250 - note_width) / 2, 105);
+    g_display_ptr->print(note);
+
+    g_display_ptr->display();
+}
+
 // Display immediate feedback when waking from tap (shows "waking" text)
 void displayTapWakeFeedback() {
     if (g_display_ptr == nullptr) return;

--- a/ios/Aquavate/Aquavate/Services/BLEStructs.swift
+++ b/ios/Aquavate/Aquavate/Services/BLEStructs.swift
@@ -71,6 +71,11 @@ struct BLECurrentState {
         (flags & 0x10) != 0
     }
 
+    /// Whether battery is below warning threshold (bit 5)
+    var isLowBattery: Bool {
+        (flags & 0x20) != 0
+    }
+
     /// Extract raw ADC value when calibration result is ready
     /// The 32-bit ADC value is split across currentWeightG (lower 16 bits) and bottleLevelMl (upper 16 bits)
     var calibrationRawADC: Int32? {

--- a/ios/Aquavate/Aquavate/Services/NotificationManager.swift
+++ b/ios/Aquavate/Aquavate/Services/NotificationManager.swift
@@ -280,6 +280,35 @@ class NotificationManager: NSObject, ObservableObject, UNUserNotificationCenterD
         }
     }
 
+    /// Schedule a low battery warning notification
+    /// Uses fixed identifier to prevent duplicate notifications
+    func scheduleLowBatteryNotification(batteryPercent: Int) {
+        guard isAuthorized else {
+            print("[Notifications] Cannot schedule low battery notification - not authorized")
+            return
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = "Low Battery"
+        content.body = "Your Aquavate bottle battery is at \(batteryPercent)%. Please charge soon."
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "bottle-low-battery",
+            content: content,
+            trigger: trigger
+        )
+
+        notificationCenter.add(request) { error in
+            if let error = error {
+                print("[Notifications] Failed to schedule low battery notification: \(error.localizedDescription)")
+            } else {
+                print("[Notifications] Scheduled low battery notification (\(batteryPercent)%)")
+            }
+        }
+    }
+
     /// Cancel all pending hydration reminder notifications
     func cancelAllPendingReminders() {
         Task {


### PR DESCRIPTION
## Summary

- **Two-tier battery warning system** with hysteresis to protect against deep discharge
- **iOS early warning** at 25%: BLE flag (`BLE_FLAG_LOW_BATTERY` 0x20) triggers red "Low Battery" badge on HomeView + push notification while bottle still works normally
- **Firmware lockout** at 20%: full-screen "charge me" on e-paper, no BLE advertising, timer-only deep sleep with 15-minute health check wakes
- **Recovery** at 25%: lockout clears automatically when battery charged above recovery threshold
- **Runtime configurable**: `SET BATTERY LOCKOUT THRESHOLD <pct>` serial command, persisted in NVS

See [Plans/075-low-battery-lockout.md](Plans/075-low-battery-lockout.md) for full design details.

### Files changed (17 files)

**Firmware (9 files):** config.h, storage.h, storage.cpp, display.h, display.cpp, main.cpp, ble_service.h, ble_service.cpp, serial_commands.cpp

**iOS (4 files):** BLEStructs.swift, BLEManager.swift, NotificationManager.swift, HomeView.swift

**Docs (4 files):** PRD.md, IOS-UX-PRD.md, PROGRESS.md, Plans/075-low-battery-lockout.md

## Test plan

- [x] Firmware builds cleanly (`platformio run`)
- [x] iOS builds cleanly (`xcodebuild` with iPhone 17 simulator)
- [x] Upload firmware, `SET BATTERY LOCKOUT THRESHOLD 93` to trigger lockout at current battery level
- [x] Verify "charge me" display appears on e-paper
- [ ] Verify serial shows lockout messages and 15-minute timer sleep
- [x] Connect USB charger, wait for health check wake, verify recovery at 98%
- [ ] Connect iOS app while battery below 25% warning threshold, verify red "Low Battery" badge
- [x] Verify push notification delivered
- [x] `SET BATTERY LOCKOUT THRESHOLD 20` to restore production threshold
- [ ] `GET BATTERY` shows correct threshold, recovery, and lockout state

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)