### PR TITLE
Fix: Sleep mode analysis crash and preserve activity history (#105)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,14 +1,13 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-02-08 (Session 38)
+**Last Updated:** 2026-02-08 (Session 39)
 **Current Branch:** `master`
-**GitHub Issue:** None
 
 ---
 
 ## Current Task
 
-No active task. Ready for next issue.
+None — ready for next task.
 
 ---
 
@@ -16,13 +15,14 @@ No active task. Ready for next issue.
 
 To resume from this progress file:
 ```
-Resume from PROGRESS.md — no active task. Low Battery Lockout (Issue #68) was just completed and merged.
+Resume from PROGRESS.md — no active task. Ready for next task.
 ```
 
 ---
 
 ## Recently Completed
 
+- **Fix App Crash in Sleep Mode Analysis (Issue #105)** - [Plan 076](Plans/076-fix-sleep-mode-analysis-crash.md) ✅ COMPLETE — CoreData `timerWakeCount` (Int16) overflowed when receiving UInt16 from firmware (max 65,535 vs 32,767). Widened `CDBackpackSession.timerWakeCount` and `CDMotionWakeEvent.durationSec` from Integer 16 to Integer 32 in CoreData model v2 (lightweight migration). Updated Int16→Int32 conversions in PersistenceController, ActivityStatsView enum, and BackupModels. Also fixed activity stats sync to merge instead of clear-and-replace, preserving historical data across firmware updates. 6 iOS files changed.
 - **Low Battery Lockout (Issue #68)** - [Plan 075](Plans/075-low-battery-lockout.md) ✅ COMPLETE — Two-tier battery warning: iOS early warning at 25% (BLE flag + push notification + red badge), firmware lockout at 20% (full-screen "charge me", timer-only deep sleep with 15-min health checks). Recovery at 25% with hysteresis. Threshold runtime-configurable via `SET BATTERY LOCKOUT THRESHOLD` serial command, persisted in NVS. 9 firmware files + 4 iOS files changed. PRD and IOS-UX-PRD updated.
 - **Fix: Drink not detected when bottle is emptied (Issue #116)** - [Plan 074](Plans/074-ble-set-time-baseline-fix.md) ✅ COMPLETE — BLE SET_TIME handler was calling `drinksInit()` on every connection, zeroing the drink detection baseline. If this happened while holding the bottle, the drink was invisible. Fix: added `drinksIsInitialized()` guard, removed forced baseline zero in `drinksInit()`, moved RTC restore before wakeup guard (survives EN-pin resets), added NVS save in `drinksSaveToRTC()` for better power-cycle fallback. Also excluded SET_TIME from activity timeout reset (was adding 30s unnecessary awake time). 4 firmware files changed.
 - **Foreground Auto-Reconnection to Bottle (Issue #114)** - [Plan 073](Plans/073-foreground-auto-reconnection.md) ✅ COMPLETE — Used `CBCentralManager.connect()` in foreground (same as background) so app auto-connects when bottle advertises without manual pull-to-refresh. Renamed all "background reconnect" APIs to "auto-reconnect". Single file change: BLEManager.swift. PRD and IOS-UX-PRD updated.

--- a/Plans/076-fix-sleep-mode-analysis-crash.md
+++ b/Plans/076-fix-sleep-mode-analysis-crash.md
@@ -1,0 +1,75 @@
+# Plan: Fix App Crash in Sleep Mode Analysis (Issue #105) ✅ COMPLETE
+
+## Context
+
+The iOS app crashes with `Fatal error: Not enough bits to represent the passed value` when saving backpack session data to CoreData. The crash occurs because `timerWakeCount` arrives from the firmware as `UInt16` (range 0–65,535) but is stored in CoreData as `Integer 16` (`Int16`, max 32,767). When a backpack session accumulates >32,767 timer wakes, `Int16(session.timerWakeCount)` triggers a Swift runtime crash.
+
+A secondary unsafe conversion also exists: `CDMotionWakeEvent.durationSec` is `Integer 16` but receives `UInt16` from firmware. While less likely to overflow (would need >9 hours awake), it's the same class of bug.
+
+## Changes
+
+### 1. Create CoreData model version 2
+
+Create `Aquavate 2.xcdatamodel` with widened types (CoreData lightweight migration handles Int16→Int32 automatically via `NSPersistentContainer`):
+
+- `CDBackpackSession.timerWakeCount`: Integer 16 → **Integer 32**
+- `CDMotionWakeEvent.durationSec`: Integer 16 → **Integer 32**
+
+Update `.xccurrentversion` to point to `Aquavate 2`.
+
+**Files:**
+- New: `ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/Aquavate 2.xcdatamodel/contents`
+- Edit: `ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/.xccurrentversion`
+
+### 2. Fix unsafe integer conversions in PersistenceController.swift
+
+- Line 391: `Int16(event.durationSec)` → `Int32(event.durationSec)`
+- Line 417: `Int16(session.timerWakeCount)` → `Int32(session.timerWakeCount)`
+
+**File:** `ios/Aquavate/Aquavate/CoreData/PersistenceController.swift`
+
+### 3. Update preview/sample data types
+
+- Line 73: sample motion events tuple type `durationSec: Int16` → `Int32`
+- Line 96: sample backpack sessions tuple type `timerWakes: Int16` → `Int32`
+
+**File:** `ios/Aquavate/Aquavate/CoreData/PersistenceController.swift`
+
+### 4. Update ActivityStatsView enum
+
+- Line 19: `case backpack(timerWakes: Int16)` → `case backpack(timerWakes: Int32)`
+
+**File:** `ios/Aquavate/Aquavate/Views/ActivityStatsView.swift`
+
+### 5. Update BackupModels struct types
+
+- `BackupMotionWakeEvent.durationSec`: `Int16` → `Int32`
+- `BackupBackpackSession.timerWakeCount`: `Int16` → `Int32`
+
+No backup format version bump needed — `Codable` decodes JSON numbers to the target type regardless, so old backups remain compatible.
+
+**File:** `ios/Aquavate/Aquavate/Models/BackupModels.swift`
+
+### 6. Preserve activity stats across firmware updates (bonus fix)
+
+The activity stats sync was doing a destructive clear-and-replace on every BLE sync, wiping historical data. Removed `clearActivityStats()` call from `saveActivityStatsToCoreData()`. The existing CoreData uniqueness constraints (`timestamp`+`bottleId`) and merge policy (`NSMergeByPropertyObjectTrumpMergePolicy`) handle deduplication, so historical records are now preserved across firmware updates and power cycles.
+
+**File:** `ios/Aquavate/Aquavate/Services/BLEManager.swift`
+
+## Files Modified (summary)
+
+| File | Change |
+|------|--------|
+| `Aquavate.xcdatamodeld/Aquavate 2.xcdatamodel/contents` | New model version with Int32 fields |
+| `Aquavate.xcdatamodeld/.xccurrentversion` | Point to new model |
+| `CoreData/PersistenceController.swift` | Fix Int16→Int32 conversions + preview data |
+| `Views/ActivityStatsView.swift` | Widen enum associated value |
+| `Models/BackupModels.swift` | Widen struct field types |
+| `Services/BLEManager.swift` | Preserve historical activity stats (merge instead of clear-and-replace) |
+
+## Verification
+
+1. Build the iOS app: `xcodebuild -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17' build` — **PASSED**
+2. Deployed to device, navigated to Activity Stats — no crash
+3. Verified activity stats persist across firmware updates (confirmed by user)
+4. CoreData lightweight migration auto-applied (Int16→Int32 widening)

--- a/ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/.xccurrentversion
+++ b/ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Aquavate.xcdatamodel</string>
+	<string>Aquavate 2.xcdatamodel</string>
 </dict>
 </plist>

--- a/ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/Aquavate 2.xcdatamodel/contents
+++ b/ios/Aquavate/Aquavate/CoreData/Aquavate.xcdatamodeld/Aquavate 2.xcdatamodel/contents
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="24C5089c" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="NO" userDefinedModelVersionIdentifier="">
+    <entity name="CDBackpackSession" representedClassName="CDBackpackSession" syncable="YES" codeGenerationType="class">
+        <attribute name="bottleId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="durationSec" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="exitReason" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="startTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="timerWakeCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="bottle" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDBottle" inverseName="backpackSessions" inverseEntity="CDBottle"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="startTimestamp"/>
+                <constraint value="bottleId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CDBottle" representedClassName="CDBottle" syncable="YES" codeGenerationType="class">
+        <attribute name="batteryPercent" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="capacityMl" optional="YES" attributeType="Integer 16" defaultValueString="750" usesScalarValueType="YES"/>
+        <attribute name="dailyGoalMl" optional="YES" attributeType="Integer 16" defaultValueString="2000" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isCalibrated" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastActivitySyncDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastSyncDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String" defaultValueString="My Bottle"/>
+        <attribute name="peripheralIdentifier" optional="YES" attributeType="String"/>
+        <attribute name="scaleFactor" optional="YES" attributeType="Float" defaultValueString="1.0" usesScalarValueType="YES"/>
+        <attribute name="tareWeightGrams" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="backpackSessions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDBackpackSession" inverseName="bottle" inverseEntity="CDBackpackSession"/>
+        <relationship name="drinkRecords" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDDrinkRecord" inverseName="bottle" inverseEntity="CDDrinkRecord"/>
+        <relationship name="motionWakeEvents" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="CDMotionWakeEvent" inverseName="bottle" inverseEntity="CDMotionWakeEvent"/>
+    </entity>
+    <entity name="CDDrinkRecord" representedClassName="CDDrinkRecord" syncable="YES" codeGenerationType="class">
+        <attribute name="amountMl" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="bottleId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="bottleLevelMl" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="drinkType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="firmwareRecordId" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="healthKitSampleUUID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="syncedToHealth" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="bottle" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDBottle" inverseName="drinkRecords" inverseEntity="CDBottle"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="timestamp"/>
+                <constraint value="bottleId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CDMotionWakeEvent" representedClassName="CDMotionWakeEvent" syncable="YES" codeGenerationType="class">
+        <attribute name="bottleId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="drinkTaken" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="durationSec" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="sleepType" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="wakeReason" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="bottle" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDBottle" inverseName="motionWakeEvents" inverseEntity="CDBottle"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="timestamp"/>
+                <constraint value="bottleId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+</model>

--- a/ios/Aquavate/Aquavate/CoreData/PersistenceController.swift
+++ b/ios/Aquavate/Aquavate/CoreData/PersistenceController.swift
@@ -70,7 +70,7 @@ struct PersistenceController {
         }
 
         // Create sample motion wake events
-        let sampleMotionEvents: [(minutesAgo: Int, durationSec: Int16, sleepType: Int16, drinkTaken: Bool)] = [
+        let sampleMotionEvents: [(minutesAgo: Int, durationSec: Int32, sleepType: Int16, drinkTaken: Bool)] = [
             (5, 45, 0, true),      // 5 min ago, 45s awake, normal sleep, drink taken
             (30, 30, 0, false),    // 30 min ago, 30s awake, normal sleep, no drink
             (90, 60, 0, true),     // 1.5 hours ago, 60s awake, normal sleep, drink taken
@@ -93,7 +93,7 @@ struct PersistenceController {
         }
 
         // Create sample backpack sessions
-        let sampleBackpackSessions: [(hoursAgo: Int, durationMin: Int, timerWakes: Int16, exitReason: Int16)] = [
+        let sampleBackpackSessions: [(hoursAgo: Int, durationMin: Int, timerWakes: Int32, exitReason: Int16)] = [
             (3, 45, 3, 0),   // 3 hours ago, 45 min duration, 3 timer wakes, exited by motion
             (12, 120, 8, 0), // 12 hours ago, 2 hour duration, 8 timer wakes, exited by motion
         ]
@@ -388,7 +388,7 @@ struct PersistenceController {
             let record = CDMotionWakeEvent(context: context)
             record.id = UUID()
             record.timestamp = Date(timeIntervalSince1970: TimeInterval(event.timestamp))
-            record.durationSec = Int16(event.durationSec)
+            record.durationSec = Int32(event.durationSec)
             record.wakeReason = Int16(event.wakeReason)
             record.sleepType = Int16(event.sleepType & 0x7F)  // Mask off drink taken flag
             record.drinkTaken = event.drinkTaken
@@ -414,7 +414,7 @@ struct PersistenceController {
             record.id = UUID()
             record.startTimestamp = Date(timeIntervalSince1970: TimeInterval(session.startTimestamp))
             record.durationSec = Int32(session.durationSec)
-            record.timerWakeCount = Int16(session.timerWakeCount)
+            record.timerWakeCount = Int32(session.timerWakeCount)
             record.exitReason = Int16(session.exitReason)
             record.bottleId = bottleId
         }

--- a/ios/Aquavate/Aquavate/Models/BackupModels.swift
+++ b/ios/Aquavate/Aquavate/Models/BackupModels.swift
@@ -50,7 +50,7 @@ struct BackupMotionWakeEvent: Codable {
     let id: UUID
     let bottleId: UUID
     let timestamp: Date
-    let durationSec: Int16
+    let durationSec: Int32
     let wakeReason: Int16
     let sleepType: Int16
     let drinkTaken: Bool
@@ -61,7 +61,7 @@ struct BackupBackpackSession: Codable {
     let bottleId: UUID
     let startTimestamp: Date
     let durationSec: Int32
-    let timerWakeCount: Int16
+    let timerWakeCount: Int32
     let exitReason: Int16
 }
 

--- a/ios/Aquavate/Aquavate/Services/BLEManager.swift
+++ b/ios/Aquavate/Aquavate/Services/BLEManager.swift
@@ -1945,9 +1945,9 @@ extension BLEManager: CBPeripheralDelegate {
             return
         }
 
-        // Clear existing activity stats before saving new ones (fresh sync)
-        PersistenceController.shared.clearActivityStats(for: bottleId)
-
+        // Merge new activity stats with existing CoreData records
+        // Uniqueness constraints (timestamp+bottleId) + merge policy handle deduplication,
+        // so historical data is preserved across firmware updates and power cycles
         // Save motion wake events
         if !motionWakeEvents.isEmpty {
             PersistenceController.shared.saveMotionWakeEvents(motionWakeEvents, for: bottleId)

--- a/ios/Aquavate/Aquavate/Views/ActivityStatsView.swift
+++ b/ios/Aquavate/Aquavate/Views/ActivityStatsView.swift
@@ -16,7 +16,7 @@ import CoreData
 
 enum SessionType {
     case normal(drinkTaken: Bool)
-    case backpack(timerWakes: Int16)
+    case backpack(timerWakes: Int32)
 }
 
 struct UnifiedSession: Identifiable {


### PR DESCRIPTION
## Summary
- **Fixed Int16 overflow crash** in Activity Stats when `timerWakeCount` exceeds 32,767 — widened CoreData fields to Int32 via model version 2 (lightweight migration)
- **Preserved historical activity data** across firmware updates — changed sync from destructive clear-and-replace to merge-based deduplication using existing uniqueness constraints

See [Plan 076](Plans/076-fix-sleep-mode-analysis-crash.md) for full details.

## Test plan
- [x] iOS app builds cleanly (`xcodebuild` — no errors or relevant warnings)
- [x] Deployed to device — Activity Stats view loads without crash
- [x] CoreData lightweight migration auto-applied (Int16→Int32)
- [x] Activity stats persist across firmware updates (confirmed on device)
- [x] Duplicate records handled by merge policy (timestamp+bottleId uniqueness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)