### PR TITLE
fix: daily reset fires at UTC midnight instead of local midnight (Issue #120)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,13 +1,13 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-02-08 (Session 39)
+**Last Updated:** 2026-04-17 (Session 40)
 **Current Branch:** `master`
 
 ---
 
 ## Current Task
 
-None — ready for next task.
+No active task. Ready for next issue.
 
 ---
 
@@ -15,13 +15,14 @@ None — ready for next task.
 
 To resume from this progress file:
 ```
-Resume from PROGRESS.md — no active task. Ready for next task.
+Resume from PROGRESS.md
 ```
 
 ---
 
 ## Recently Completed
 
+- **Fix Timezone / Daily Reset & BLE Sync Corruption (Issue #120)** - [Plan 077](Plans/077-fix-timezone-daily-reset.md) ✅ COMPLETE — Daily reset was firing at UTC midnight (1am BST instead of midnight BST), and a race condition could corrupt BLE sync data during the UTC/BST gap. Fix: iOS now sends timezone offset (hours) alongside UTC timestamp in SET_TIME (5→6 bytes); firmware stores it and uses it only for reset boundary math; all record timestamps remain true UTC. `getCurrentUnixTime()` returns pure UTC; `getTodayResetTimestamp()` and `getSecondsUntilRollover()` compute local midnight as UTC via signed arithmetic. Added `volatile g_ble_sync_in_progress` guard (set at sync START, cleared at COMPLETE/error/disconnect) to prevent daily reset mid-sync. E-paper sleep display and rollover wake check now use local time. 6 files changed (4 firmware, 2 iOS). Deploy: flash firmware first, then iOS — 6-byte SET_TIME is not backward compatible.
 - **Fix App Crash in Sleep Mode Analysis (Issue #105)** - [Plan 076](Plans/076-fix-sleep-mode-analysis-crash.md) ✅ COMPLETE — CoreData `timerWakeCount` (Int16) overflowed when receiving UInt16 from firmware (max 65,535 vs 32,767). Widened `CDBackpackSession.timerWakeCount` and `CDMotionWakeEvent.durationSec` from Integer 16 to Integer 32 in CoreData model v2 (lightweight migration). Updated Int16→Int32 conversions in PersistenceController, ActivityStatsView enum, and BackupModels. Also fixed activity stats sync to merge instead of clear-and-replace, preserving historical data across firmware updates. 6 iOS files changed.
 - **Low Battery Lockout (Issue #68)** - [Plan 075](Plans/075-low-battery-lockout.md) ✅ COMPLETE — Two-tier battery warning: iOS early warning at 25% (BLE flag + push notification + red badge), firmware lockout at 20% (full-screen "charge me", timer-only deep sleep with 15-min health checks). Recovery at 25% with hysteresis. Threshold runtime-configurable via `SET BATTERY LOCKOUT THRESHOLD` serial command, persisted in NVS. 9 firmware files + 4 iOS files changed. PRD and IOS-UX-PRD updated.
 - **Fix: Drink not detected when bottle is emptied (Issue #116)** - [Plan 074](Plans/074-ble-set-time-baseline-fix.md) ✅ COMPLETE — BLE SET_TIME handler was calling `drinksInit()` on every connection, zeroing the drink detection baseline. If this happened while holding the bottle, the drink was invisible. Fix: added `drinksIsInitialized()` guard, removed forced baseline zero in `drinksInit()`, moved RTC restore before wakeup guard (survives EN-pin resets), added NVS save in `drinksSaveToRTC()` for better power-cycle fallback. Also excluded SET_TIME from activity timeout reset (was adding 30s unnecessary awake time). 4 firmware files changed.

--- a/Plans/077-fix-timezone-daily-reset.md
+++ b/Plans/077-fix-timezone-daily-reset.md
@@ -1,0 +1,179 @@
+# Plan: Fix Timezone / Daily Reset & BLE Sync Corruption ✅ COMPLETE
+
+**GitHub Issue:** [#120](https://github.com/bowerhaus/Aquavate/issues/120)
+**Branch:** `fix-timezone-daily-reset`
+
+## Context
+
+The device runs with `g_timezone_offset = 0` (default — no way to set it from iOS, only serial). This causes two linked bugs:
+
+1. **Daily reset at wrong time**: `getTodayResetTimestamp()` calls `getCurrentUnixTime()` (pure UTC) then `gmtime_r()` and resets at `tm_hour == 0` UTC = **1am BST** in summer. User sees yesterday's total from midnight BST until 1am.
+
+2. **BLE sync corruption during the UTC/BST midnight gap**: Between 23:00 UTC (midnight BST) and 00:00 UTC (1am BST), a user connecting iOS triggers a BLE sync immediately. The main loop checks `current_tm.tm_hour == DRINK_DAILY_RESET_HOUR` at exactly 00:00 UTC and calls `drinksResetDaily()` — which marks records as deleted — while the BLE RTOS task is still iterating those same records to send chunks. The chunk ends up with a `recordCount` that no longer matches the data, failing iOS's size validation and reporting "corrupted data error".
+
+The fix: iOS sends timezone offset (hours) alongside the UTC timestamp on every connection. Firmware stores it and uses it **only** to shift the reset boundary — all record timestamps remain true UTC.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `firmware/include/ble_service.h` | Extend `BLE_SetTimeCommand` (5→6 bytes: add `int8_t tz_offset_hours`) |
+| `firmware/src/ble_service.cpp` | Read and store `tz_offset_hours` in SET_TIME handler |
+| `firmware/src/drinks.cpp` | Fix `getTodayResetTimestamp()` and `getSecondsUntilRollover()` to use local midnight expressed as UTC; strip offset from `getCurrentUnixTime()` |
+| `firmware/src/main.cpp` | Fix rollover wake hour check (~line 979) and sleep-display time (~line 1188) to use local time; add sync-guard |
+| `ios/Aquavate/Aquavate/Services/BLEStructs.swift` | Update `BLECommand.setTime()` to include timezone offset byte |
+| `ios/Aquavate/Aquavate/Services/BLEManager.swift` | Update `syncDeviceTime()` to send current timezone offset |
+
+## Caller Audit: getCurrentUnixTime()
+
+`getCurrentUnixTime()` currently returns `UTC + g_timezone_offset * 3600`. Removing the offset makes it return true UTC. Each caller needs to be checked:
+
+| Caller | Needs local time? | Action |
+|--------|------------------|--------|
+| `drinks.cpp:203` record.timestamp | No — store UTC | ✓ correct after fix |
+| `drinks.cpp:57` getTodayResetTimestamp | Yes — boundary math | Fix in Step 3 |
+| `drinks.cpp:85` getSecondsUntilRollover | Yes — boundary math | Fix in Step 3 |
+| `main.cpp:973` rollover wake hour check | Yes — local hour | Fix in Step 4 |
+| `main.cpp:1188` e-paper sleep display time | Yes — local hour | Fix in Step 4 |
+| `ble_service.cpp:953` currentState.timestamp | No — send UTC | ✓ correct after fix |
+| `activity_stats.cpp:99,151,162,176` session timestamps | No — store UTC | ✓ correct after fix |
+
+Note: The many `tv.tv_sec + (g_timezone_offset * 3600)` patterns in display.cpp and main.cpp bypass `getCurrentUnixTime()` entirely — they are already correct and untouched.
+
+## Implementation Steps
+
+### Step 1 — Extend BLE_SetTimeCommand (firmware/include/ble_service.h)
+```cpp
+struct __attribute__((packed)) BLE_SetTimeCommand {
+    uint8_t  command;           // BLE_CMD_SET_TIME (0x10)
+    uint32_t timestamp;         // UTC Unix timestamp
+    int8_t   tz_offset_hours;   // Local timezone offset in whole hours (e.g. +1 for BST)
+};
+// Size: 6 bytes (was 5)
+```
+
+### Step 2 — Handle tz_offset_hours in SET_TIME handler (firmware/src/ble_service.cpp, ~line 183)
+
+> **Note: firmware and iOS must be deployed together** — the 6-byte SET_TIME is not backward compatible with old firmware, and old iOS will not send timezone offset to new firmware. Flash firmware first, then install the new iOS build.
+
+The existing check `value.length() == sizeof(BLE_SetTimeCommand)` will automatically match 6 bytes (the new size). Read and store the timezone offset:
+```cpp
+if (value.length() == sizeof(BLE_SetTimeCommand) && value[0] == BLE_CMD_SET_TIME) {
+    BLE_SetTimeCommand timeCmd;
+    memcpy(&timeCmd, value.data(), sizeof(BLE_SetTimeCommand));
+    // ... existing RTC set logic ...
+    g_timezone_offset = timeCmd.tz_offset_hours;
+    storageSaveTimezone(g_timezone_offset);
+}
+```
+
+### Step 3 — Fix daily reset boundary to use local midnight (firmware/src/drinks.cpp)
+
+**Change `getCurrentUnixTime()` (drinks.cpp:37-42)** to remove the offset addition — it should return true UTC:
+```cpp
+uint32_t getCurrentUnixTime() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (uint32_t)tv.tv_sec;  // true UTC; callers add offset as needed
+}
+```
+
+**Fix `getTodayResetTimestamp()` (drinks.cpp:56-75)** to compute local midnight as a UTC timestamp:
+```cpp
+static uint32_t getTodayResetTimestamp() {
+    uint32_t current_utc = getCurrentUnixTime();
+    uint32_t local_time = current_utc + (g_timezone_offset * 3600);
+    time_t local_t = local_time;
+    struct tm local_tm;
+    gmtime_r(&local_t, &local_tm);
+
+    struct tm reset_tm = local_tm;
+    reset_tm.tm_hour = DRINK_DAILY_RESET_HOUR;
+    reset_tm.tm_min = 0;
+    reset_tm.tm_sec = 0;
+    uint32_t local_midnight_adjusted = (uint32_t)mktime(&reset_tm);
+    uint32_t reset_utc = local_midnight_adjusted - (g_timezone_offset * 3600);
+
+    if (local_tm.tm_hour < DRINK_DAILY_RESET_HOUR) {
+        reset_utc -= 24 * 3600;
+    }
+
+    return reset_utc;
+}
+```
+
+Apply the same pattern to `getSecondsUntilRollover()` (lines ~80-110).
+
+### Step 4 — Fix main.cpp callers that need local time
+
+**4a. Rollover wake check (main.cpp:973-979)** — must compare local hour, not UTC:
+```cpp
+uint32_t current_utc = getCurrentUnixTime();
+time_t local_t = current_utc + (g_timezone_offset * 3600);
+struct tm current_tm;
+gmtime_r(&local_t, &current_tm);
+if (current_tm.tm_hour == DRINK_DAILY_RESET_HOUR && current_tm.tm_min <= 10) {
+```
+
+Add a sync-guard to prevent the race condition (reset fires during BLE sync):
+```cpp
+extern bool g_ble_sync_in_progress;  // tracked in ble_service.cpp
+if (!g_ble_sync_in_progress && current_tm.tm_hour == DRINK_DAILY_RESET_HOUR && current_tm.tm_min <= 10) {
+```
+Verify `g_ble_sync_in_progress` is exported from ble_service.cpp; if not, add it there.
+
+**4b. Sleep-display time (main.cpp:1188-1192)** — must use local time for e-paper:
+```cpp
+uint32_t current_utc = getCurrentUnixTime();
+time_t local_t = current_utc + (g_timezone_offset * 3600);
+struct tm current_tm;
+gmtime_r(&local_t, &current_tm);
+time_hour = current_tm.tm_hour;
+time_minute = current_tm.tm_min;
+```
+
+### Step 5 — iOS: send timezone offset in BLECommand.setTime (BLEStructs.swift)
+
+```swift
+static func setTime(timestamp: UInt32, tzOffsetHours: Int8) -> Data {
+    var data = Data(count: 6)
+    data.withUnsafeMutableBytes { ptr in
+        guard let base = ptr.baseAddress else { return }
+        base.storeBytes(of: UInt8(BLE_CMD_SET_TIME), as: UInt8.self)
+        base.storeBytes(of: timestamp, toByteOffset: 1, as: UInt32.self)
+        base.storeBytes(of: tzOffsetHours, toByteOffset: 5, as: Int8.self)
+    }
+    return data
+}
+```
+
+### Step 6 — iOS: send offset in syncDeviceTime (BLEManager.swift, ~line 1665)
+
+```swift
+func syncDeviceTime() {
+    let currentTimestamp = UInt32(Date().timeIntervalSince1970)
+    let tzOffsetHours = Int8(TimeZone.current.secondsFromGMT() / 3600)
+    let data = BLECommand.setTime(timestamp: currentTimestamp, tzOffsetHours: tzOffsetHours)
+    peripheral.writeValue(data, for: characteristic, type: .withResponse)
+    logger.info("Sent SET_TIME: timestamp=\(currentTimestamp), tz=\(tzOffsetHours)h")
+}
+```
+
+## What This Fixes
+
+| Problem | Before | After |
+|---------|--------|-------|
+| Daily reset time | 1am BST (UTC midnight) | Midnight BST (local midnight) |
+| Sync corruption | Race: reset fires during sync at 00:00 UTC | Reset fires at 23:00 UTC (already done before user wakes and syncs) |
+| Display time (e-paper) | UTC = 1 hour behind in BST | Correct local time via stored offset |
+| Timezone offset | Static 0, serial-only | Auto-updated from iOS on every connection |
+| Record timestamps | True UTC (unchanged, correct) | True UTC (unchanged) |
+
+## Verification
+
+1. Build firmware: `cd firmware && ~/.platformio/penv/bin/platformio run`
+2. Connect iOS app — check serial log shows `tz=+1h` (BST)
+3. Serial log: confirm `getTodayResetTimestamp()` boundary is at 23:00 UTC when in BST (+1)
+4. Simulate midnight crossing: use `t` serial command to set time to 22:55 BST, watch daily reset fire at 23:00 UTC (midnight BST), confirm no spurious reset at 00:00 UTC
+5. During active BLE sync, confirm no "Invalid drink data chunk" errors in iOS console
+6. Build iOS: `cd ios/Aquavate && xcodebuild -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17' build`

--- a/firmware/include/ble_service.h
+++ b/firmware/include/ble_service.h
@@ -132,10 +132,11 @@ struct __attribute__((packed)) BLE_DeviceSettings {
 // Device Settings flags
 #define DEVICE_SETTINGS_FLAG_SHAKE_EMPTY_ENABLED    0x01  // Bit 0: Shake-to-empty gesture enabled
 
-// Set Time Command (5 bytes) - different from standard 4-byte command
+// Set Time Command (6 bytes) - different from standard 4-byte command
 struct __attribute__((packed)) BLE_SetTimeCommand {
-    uint8_t  command;       // Always 0x10
-    uint32_t timestamp;     // Unix timestamp (seconds since 1970)
+    uint8_t  command;           // Always 0x10
+    uint32_t timestamp;         // UTC Unix timestamp (seconds since 1970)
+    int8_t   tz_offset_hours;   // Local timezone offset in whole hours (e.g. +1 for BST)
 };
 
 // Activity Stats Summary (12 bytes) - first response to GET_ACTIVITY_SUMMARY

--- a/firmware/src/ble_service.cpp
+++ b/firmware/src/ble_service.cpp
@@ -95,6 +95,9 @@ static volatile int32_t g_cal_last_adc = 0;         // Last measured raw ADC val
 static volatile bool g_ble_calibration_start_requested = false;   // iOS requested calibration start
 static volatile bool g_ble_calibration_cancel_requested = false;  // iOS requested calibration cancel
 
+// Sync-in-progress guard — prevents daily reset firing mid-sync (read by main.cpp)
+volatile bool g_ble_sync_in_progress = false;
+
 // Forward declaration for sync complete notification
 static void bleNotifyCurrentStateUpdate();
 
@@ -178,14 +181,14 @@ class CommandCallbacks : public NimBLECharacteristicCallbacks {
         // Get written data
         std::string value = pCharacteristic->getValue();
 
-        // Check for SET_TIME command (5 bytes)
+        // Check for SET_TIME command (6 bytes)
         // Note: SET_TIME is housekeeping, not user interaction — don't reset activity timeout
         if (value.length() == sizeof(BLE_SetTimeCommand) && value[0] == BLE_CMD_SET_TIME) {
             g_ble_data_activity = false;  // Undo the activity flag set above
             BLE_SetTimeCommand timeCmd;
             memcpy(&timeCmd, value.data(), sizeof(BLE_SetTimeCommand));
 
-            BLE_DEBUG_F("Command: SET_TIME, timestamp=%u", timeCmd.timestamp);
+            BLE_DEBUG_F("Command: SET_TIME, timestamp=%u, tz=%+dh", timeCmd.timestamp, timeCmd.tz_offset_hours);
 
             // Set the ESP32 RTC
             struct timeval tv;
@@ -198,6 +201,12 @@ class CommandCallbacks : public NimBLECharacteristicCallbacks {
                 // Mark time as valid
                 g_time_valid = true;
                 storageSaveTimeValid(true);
+
+                // Store timezone offset sent by iOS
+                extern int8_t g_timezone_offset;
+                g_timezone_offset = timeCmd.tz_offset_hours;
+                storageSaveTimezone(g_timezone_offset);
+                Serial.printf("[BLE] SET_TIME: tz=%+dh\n", g_timezone_offset);
 
                 // Initialize drink tracking if not already initialized
                 if (!drinksIsInitialized()) {
@@ -447,6 +456,7 @@ class SyncControlCallbacks : public NimBLECharacteristicCallbacks {
 
                 if (syncBuffer == nullptr) {
                     BLE_DEBUG("ERROR: Failed to allocate sync buffer");
+                    g_ble_sync_in_progress = false;
                     syncControl.status = 0; // IDLE
                     syncControl.count = 0;
                     pCharacteristic->setValue((uint8_t*)&syncControl, sizeof(syncControl));
@@ -458,6 +468,7 @@ class SyncControlCallbacks : public NimBLECharacteristicCallbacks {
                     BLE_DEBUG("ERROR: Failed to load unsynced records");
                     delete[] syncBuffer;
                     syncBuffer = nullptr;
+                    g_ble_sync_in_progress = false;
                     syncControl.status = 0; // IDLE
                     syncControl.count = 0;
                     pCharacteristic->setValue((uint8_t*)&syncControl, sizeof(syncControl));
@@ -470,6 +481,7 @@ class SyncControlCallbacks : public NimBLECharacteristicCallbacks {
                 syncControl.chunk_size = (request.chunk_size > 0 && request.chunk_size <= 20)
                                         ? request.chunk_size : 20;
                 syncControl.status = 1; // IN_PROGRESS
+                g_ble_sync_in_progress = true;
                 syncCurrentChunk = 0;
 
                 BLE_DEBUG_F("Sync started: %d records, chunk_size=%d",
@@ -507,6 +519,7 @@ class SyncControlCallbacks : public NimBLECharacteristicCallbacks {
                     syncBufferSize = 0;
 
                     // Update state
+                    g_ble_sync_in_progress = false;
                     syncControl.status = 2; // COMPLETE
                     pCharacteristic->setValue((uint8_t*)&syncControl, sizeof(syncControl));
 
@@ -587,6 +600,9 @@ class AquavateServerCallbacks : public NimBLEServerCallbacks {
             g_cal_measuring = false;
             g_cal_result_ready = false;
         }
+
+        // Clear sync guard so daily reset isn't permanently blocked
+        g_ble_sync_in_progress = false;
 
         // Restart advertising for next connection
         // Note: Main loop will handle advertising timeout logic

--- a/firmware/src/drinks.cpp
+++ b/firmware/src/drinks.cpp
@@ -33,12 +33,11 @@ RTC_DATA_ATTR uint32_t rtc_drinks_magic = 0;
 RTC_DATA_ATTR int32_t rtc_last_stable_adc = 0;
 RTC_DATA_ATTR float rtc_last_stable_water_ml = 0.0f;
 
-// Helper: Get current Unix timestamp with timezone offset
+// Helper: Get current UTC Unix timestamp
 uint32_t getCurrentUnixTime() {
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    // Apply timezone offset (convert hours to seconds)
-    return tv.tv_sec + (g_timezone_offset * 3600);
+    return (uint32_t)tv.tv_sec;  // true UTC; callers add g_timezone_offset as needed
 }
 
 // Helper: Save timestamp to NVS on drink/refill events (for time persistence)
@@ -52,29 +51,33 @@ static void saveTimestampOnEvent(const char* event_type) {
     }
 }
 
-// Helper: Calculate today's 4am boundary timestamp
+// Helper: Calculate today's 4am boundary as a UTC timestamp using stored timezone offset
 static uint32_t getTodayResetTimestamp() {
-    uint32_t current_time = getCurrentUnixTime();
-    time_t current_t = current_time;
-    struct tm current_tm;
-    gmtime_r(&current_t, &current_tm);
+    uint32_t current_utc = getCurrentUnixTime();
+    // Shift to local time for boundary math (signed arithmetic avoids uint32 wrap hazard)
+    time_t local_t = (time_t)current_utc + (g_timezone_offset * 3600);
+    struct tm local_tm;
+    gmtime_r(&local_t, &local_tm);  // gives local time fields (offset already applied)
 
-    // Calculate timestamp for 4am today
-    struct tm reset_tm = current_tm;
+    // Compute local 4am as a "fake UTC" via mktime (ESP32 runs UTC so mktime ≈ timegm)
+    struct tm reset_tm = local_tm;
     reset_tm.tm_hour = DRINK_DAILY_RESET_HOUR;
     reset_tm.tm_min = 0;
     reset_tm.tm_sec = 0;
-    uint32_t today_reset_timestamp = (uint32_t)mktime(&reset_tm);
+    uint32_t local_reset = (uint32_t)mktime(&reset_tm);
 
-    // If we're before 4am today, use yesterday's 4am as the reset boundary
-    if (current_tm.tm_hour < DRINK_DAILY_RESET_HOUR) {
-        today_reset_timestamp -= 24 * 3600;  // Subtract 24 hours
+    // Convert back to true UTC
+    uint32_t reset_utc = (uint32_t)((time_t)local_reset - (g_timezone_offset * 3600));
+
+    // If local time is before 4am, use yesterday's local 4am (= go back 24h in UTC)
+    if (local_tm.tm_hour < DRINK_DAILY_RESET_HOUR) {
+        reset_utc -= 24 * 3600;
     }
 
-    return today_reset_timestamp;
+    return reset_utc;
 }
 
-// Calculate seconds until next 4am rollover
+// Calculate seconds until next 4am local-time rollover
 // Used for timer wake scheduling in deep sleep
 // Returns 0 if time is not valid
 uint32_t getSecondsUntilRollover() {
@@ -82,26 +85,29 @@ uint32_t getSecondsUntilRollover() {
         return 0;  // No timer if time not set
     }
 
-    uint32_t current_time = getCurrentUnixTime();
-    time_t current_t = current_time;
-    struct tm current_tm;
-    gmtime_r(&current_t, &current_tm);
+    uint32_t current_utc = getCurrentUnixTime();
+    // Shift to local time for boundary comparison (signed arithmetic avoids uint32 wrap hazard)
+    time_t local_t = (time_t)current_utc + (g_timezone_offset * 3600);
+    struct tm local_tm;
+    gmtime_r(&local_t, &local_tm);  // local time fields
 
-    // Calculate timestamp for next 4am
-    struct tm next_reset_tm = current_tm;
+    // Compute next local 4am as a "fake UTC" via mktime (ESP32 runs UTC so mktime ≈ timegm)
+    struct tm next_reset_tm = local_tm;
     next_reset_tm.tm_hour = DRINK_DAILY_RESET_HOUR;
     next_reset_tm.tm_min = 0;
     next_reset_tm.tm_sec = 0;
-    uint32_t next_reset_timestamp = (uint32_t)mktime(&next_reset_tm);
+    uint32_t next_reset_local = (uint32_t)mktime(&next_reset_tm);
 
-    // If we're at or past 4am today, target tomorrow's 4am
-    if (current_tm.tm_hour >= DRINK_DAILY_RESET_HOUR) {
-        next_reset_timestamp += 24 * 3600;  // Add 24 hours
+    // Convert back to true UTC
+    uint32_t next_reset_utc = (uint32_t)((time_t)next_reset_local - (g_timezone_offset * 3600));
+
+    // If local time is at or past 4am, target tomorrow's local 4am
+    if (local_tm.tm_hour >= DRINK_DAILY_RESET_HOUR) {
+        next_reset_utc += 24 * 3600;
     }
 
-    // Calculate seconds until rollover
-    if (next_reset_timestamp > current_time) {
-        return next_reset_timestamp - current_time;
+    if (next_reset_utc > current_utc) {
+        return next_reset_utc - current_utc;
     }
 
     return 0;  // Safety fallback

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -98,6 +98,10 @@ int8_t g_timezone_offset = 0;  // UTC offset in hours
 bool g_time_valid = false;     // Has time been set?
 bool g_rtc_ds3231_present = false;  // DS3231 RTC detected (future)
 
+#if ENABLE_BLE
+extern bool g_ble_sync_in_progress;  // Defined in ble_service.cpp
+#endif
+
 // Shake to empty gesture state (shake-while-inverted)
 bool g_cancel_drink_pending = false;  // Set when shake gesture detected, cleared on upright stable
 
@@ -968,18 +972,23 @@ void setup() {
         if (rtc_rollover_wake_pending) {
             rtc_rollover_wake_pending = false;  // Clear flag
 
-            // Verify we're near 4am (within 10 minutes after rollover time)
+            // Verify we're near 4am local time (within 10 minutes after rollover time)
             if (g_time_valid) {
-                uint32_t current_time = getCurrentUnixTime();
-                time_t current_t = current_time;
+                uint32_t current_utc = getCurrentUnixTime();
+                time_t local_t = current_utc + (g_timezone_offset * 3600);
                 struct tm current_tm;
-                gmtime_r(&current_t, &current_tm);
+                gmtime_r(&local_t, &current_tm);
 
-                // Check if within 10 minutes after 4am
-                if (current_tm.tm_hour == DRINK_DAILY_RESET_HOUR && current_tm.tm_min <= 10) {
+                // Check if within 10 minutes after local 4am; skip if BLE sync mid-flight
+#if ENABLE_BLE
+                bool sync_active = g_ble_sync_in_progress;
+#else
+                bool sync_active = false;
+#endif
+                if (!sync_active && current_tm.tm_hour == DRINK_DAILY_RESET_HOUR && current_tm.tm_min <= 10) {
                     is_rollover_wake = true;
                     Serial.println("=== DAILY ROLLOVER WAKE ===");
-                    Serial.printf("Time: %02d:%02d - Refreshing display with reset daily total\n",
+                    Serial.printf("Time: %02d:%02d local - Refreshing display with reset daily total\n",
                                   current_tm.tm_hour, current_tm.tm_min);
                 }
             }
@@ -1185,10 +1194,10 @@ void setup() {
         uint8_t time_hour = DRINK_DAILY_RESET_HOUR;
         uint8_t time_minute = 0;
         if (g_time_valid) {
-            uint32_t current_time = getCurrentUnixTime();
-            time_t current_t = current_time;
+            uint32_t current_utc = getCurrentUnixTime();
+            time_t local_t = current_utc + (g_timezone_offset * 3600);
             struct tm current_tm;
-            gmtime_r(&current_t, &current_tm);
+            gmtime_r(&local_t, &current_tm);
             time_hour = current_tm.tm_hour;
             time_minute = current_tm.tm_min;
         }

--- a/ios/Aquavate/Aquavate/Services/BLEManager.swift
+++ b/ios/Aquavate/Aquavate/Services/BLEManager.swift
@@ -1670,9 +1670,10 @@ extension BLEManager: CBPeripheralDelegate {
         }
 
         let currentTimestamp = UInt32(Date().timeIntervalSince1970)
-        let data = BLECommand.setTime(timestamp: currentTimestamp)
+        let tzOffsetHours = Int8(TimeZone.current.secondsFromGMT() / 3600)
+        let data = BLECommand.setTime(timestamp: currentTimestamp, tzOffsetHours: tzOffsetHours)
         peripheral.writeValue(data, for: characteristic, type: .withResponse)
-        logger.info("Sent SET_TIME command with timestamp: \(currentTimestamp)")
+        logger.info("Sent SET_TIME: timestamp=\(currentTimestamp), tz=\(tzOffsetHours)h")
     }
 
     /// Auto-sync time on connection if device time is invalid

--- a/ios/Aquavate/Aquavate/Services/BLEStructs.swift
+++ b/ios/Aquavate/Aquavate/Services/BLEStructs.swift
@@ -413,16 +413,15 @@ struct BLECommand {
         return data
     }
 
-    /// Create SET_TIME command (0x10) with Unix timestamp
-    /// Note: param2 is only 16 bits, so we need to pack timestamp differently
-    /// The firmware expects the full 32-bit timestamp, so we'll use a different approach
-    static func setTime(timestamp: UInt32) -> Data {
-        // For time sync, we send 5 bytes: command + 4-byte timestamp
-        var data = Data(count: 5)
+    /// Create SET_TIME command (0x10) with UTC Unix timestamp and timezone offset
+    /// Sends 6 bytes: command + 4-byte UTC timestamp + 1-byte signed tz offset (hours)
+    static func setTime(timestamp: UInt32, tzOffsetHours: Int8) -> Data {
+        var data = Data(count: 6)
         data.withUnsafeMutableBytes { ptr in
             guard let baseAddress = ptr.baseAddress else { return }
             baseAddress.storeBytes(of: UInt8(0x10), as: UInt8.self)
             baseAddress.storeBytes(of: timestamp, toByteOffset: 1, as: UInt32.self)
+            baseAddress.storeBytes(of: tzOffsetHours, toByteOffset: 5, as: Int8.self)
         }
         return data
     }


### PR DESCRIPTION
## Summary

- **BLE protocol extended**: `BLE_SetTimeCommand` grows from 5→6 bytes, adding `int8_t tz_offset_hours`. iOS sends current timezone offset on every `syncDeviceTime()` call; firmware stores it via `storageSaveTimezone()` and logs `[BLE] SET_TIME: tz=+1h`.
- **Reset boundary fixed**: `getCurrentUnixTime()` now returns true UTC. `getTodayResetTimestamp()` and `getSecondsUntilRollover()` in `drinks.cpp` shift to local time for boundary math, then convert back to UTC — so the 4am reset fires at 4am BST (03:00 UTC), not 4am UTC (05:00 BST).
- **Race condition fixed**: Added `volatile g_ble_sync_in_progress` flag (set at sync START, cleared at COMPLETE / error / disconnect). The rollover wake check in `main.cpp` skips the daily reset while a BLE sync is mid-flight, preventing chunk-count corruption.
- **Display time fixed**: E-paper sleep-display and rollover wake log now use local time.

## Files changed

| File | Change |
|------|--------|
| `firmware/include/ble_service.h` | `BLE_SetTimeCommand` 5→6 bytes (adds `tz_offset_hours`) |
| `firmware/src/ble_service.cpp` | SET_TIME handler stores timezone; `volatile g_ble_sync_in_progress` flag managed across sync/disconnect |
| `firmware/src/drinks.cpp` | `getCurrentUnixTime()` returns true UTC; boundary functions use signed local-time arithmetic |
| `firmware/src/main.cpp` | Rollover wake check uses local time + sync guard; sleep display uses local time |
| `ios/.../BLEStructs.swift` | `setTime()` sends 6 bytes including `tzOffsetHours: Int8` |
| `ios/.../BLEManager.swift` | `syncDeviceTime()` derives offset from `TimeZone.current.secondsFromGMT() / 3600` |

## Deploy note

⚠️ Flash firmware **before** installing the new iOS build — the 6-byte SET_TIME is not backward compatible with old firmware.

## Documentation

Reviewed PRD, iOS-UX-PRD, Plan 006 (USB time), and Plan 007 (daily tracking). No live docs reference the SET_TIME byte format or the UTC-specific reset behaviour, so no doc updates were needed.

## Tests & linting

No test suite or lint tooling configured in this project.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)