### PR TITLE
feat: introduce minimum viable unit tests for firmware and iOS app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,26 @@ pio device monitor         # Serial monitor
 
 **Status:** Skeleton only - CoreBluetooth, CoreData, and UI implementation pending.
 
+### Before Opening a Firmware PR
+
+1. **If your changes touch `calibration.cpp`, `weight.cpp`, or `drinks.cpp`**, run the unit tests:
+   ```bash
+   cd firmware && ~/.platformio/penv/bin/platformio test -e native
+   ```
+   All tests must pass. No hardware required — runs on Mac in seconds.
+2. **Build** for Adafruit Feather and verify no compile errors.
+3. **Flash and manual-test** the changed behaviour on device.
+
+### Before Opening an iOS PR
+
+1. **If your changes touch `HydrationReminderService.swift`**, run the unit tests:
+   ```bash
+   cd ios/Aquavate && xcodebuild test -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17'
+   ```
+   All tests must pass.
+2. **Build** and verify no compile errors.
+3. **Manual-test** the changed behaviour on simulator or device.
+
 ### Documentation Updates
 
 When completing work:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,18 @@ cd firmware
 
 **Note:** The user will handle firmware uploads and device restarts manually. Do not attempt to upload firmware or wait for upload confirmation - just build and inform the user when ready.
 
+### Firmware Unit Tests (no hardware required)
+```bash
+cd firmware
+~/.platformio/penv/bin/platformio test -e native
+```
+
+- Tests run on the Mac via the host compiler — no board, no USB cable needed
+- Three test suites: `test_calibration` (scale-factor math), `test_weight` (outlier removal), `test_drinks` (timezone reset, drink detection, daily totals)
+- **When to run:** if your changes touch `calibration.cpp`, `weight.cpp`, or `drinks.cpp`, run these before opening a PR
+- Tests live in `firmware/test/test_*/` — see those files for what's covered
+- Hardware-dependent code (display, BLE, deep sleep, RTC) is tested manually on device only
+
 ### Git Commits and Pull Requests
 
 **IMPORTANT:** Never create git commits or pull requests unless the user explicitly asks you to. Always wait for an explicit instruction like "commit this" or "create a PR" before running any git commit or PR creation commands.
@@ -157,6 +169,18 @@ xcodebuild -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17'
 ```
 
 **Important:** Always use `iPhone 17` as the simulator name for test builds. Other common simulator names (e.g., iPhone 16) are not available on this system.
+
+### iOS Unit Tests (no hardware required)
+```bash
+cd ios/Aquavate
+xcodebuild test -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+
+**IMPORTANT:** iOS tests are slow and expensive — run them **at most once per session**, only immediately before opening a PR. Never run them for verification loops, counting output, or repeated checks. Do NOT re-run just to confirm pass/fail count.
+
+- Tests cover pure business logic only — BLE/CoreBluetooth, HealthKit, and UI are tested manually on device
+- Tests live in `ios/Aquavate/AquavateTests/` — see those files for what's covered
+- **When to run:** if your changes touch `HydrationReminderService.swift`, run these before opening a PR
 
 ## Reference Documentation
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,13 +1,13 @@
 # Aquavate - Active Development Progress
 
-**Last Updated:** 2026-04-17 (Session 40)
-**Current Branch:** `master`
+**Last Updated:** 2026-04-17 (Session 42)
+**Current Branch:** `introduce-unit-tests` → PR open
 
 ---
 
 ## Current Task
 
-No active task. Ready for next issue.
+**None — PR open for Plan 078.**
 
 ---
 
@@ -22,6 +22,7 @@ Resume from PROGRESS.md
 
 ## Recently Completed
 
+- **Introduce Unit Tests** - [Plan 078](Plans/078-introduce-unit-tests.md) ✅ COMPLETE — Added minimum viable unit tests to firmware and iOS app. Firmware: PlatformIO `[env:native]` with Unity framework; host stubs for Arduino.h/NVS/RTC_DATA_ATTR; injectable `getCurrentUnixTime()`; 3 test suites (`test_calibration`, `test_weight`, `test_drinks`) — 30/30 green. iOS: XCTest target `AquavateTests`; injectable `now: () -> Date` on `HydrationReminderService`; `HydrationReminderServiceTests.swift` covering pace, deficit, urgency, throttle reset — 16/16 green. CLAUDE.md and AGENTS.md updated with test run instructions and pre-PR checklist.
 - **Fix Timezone / Daily Reset & BLE Sync Corruption (Issue #120)** - [Plan 077](Plans/077-fix-timezone-daily-reset.md) ✅ COMPLETE — Daily reset was firing at UTC midnight (1am BST instead of midnight BST), and a race condition could corrupt BLE sync data during the UTC/BST gap. Fix: iOS now sends timezone offset (hours) alongside UTC timestamp in SET_TIME (5→6 bytes); firmware stores it and uses it only for reset boundary math; all record timestamps remain true UTC. `getCurrentUnixTime()` returns pure UTC; `getTodayResetTimestamp()` and `getSecondsUntilRollover()` compute local midnight as UTC via signed arithmetic. Added `volatile g_ble_sync_in_progress` guard (set at sync START, cleared at COMPLETE/error/disconnect) to prevent daily reset mid-sync. E-paper sleep display and rollover wake check now use local time. 6 files changed (4 firmware, 2 iOS). Deploy: flash firmware first, then iOS — 6-byte SET_TIME is not backward compatible.
 - **Fix App Crash in Sleep Mode Analysis (Issue #105)** - [Plan 076](Plans/076-fix-sleep-mode-analysis-crash.md) ✅ COMPLETE — CoreData `timerWakeCount` (Int16) overflowed when receiving UInt16 from firmware (max 65,535 vs 32,767). Widened `CDBackpackSession.timerWakeCount` and `CDMotionWakeEvent.durationSec` from Integer 16 to Integer 32 in CoreData model v2 (lightweight migration). Updated Int16→Int32 conversions in PersistenceController, ActivityStatsView enum, and BackupModels. Also fixed activity stats sync to merge instead of clear-and-replace, preserving historical data across firmware updates. 6 iOS files changed.
 - **Low Battery Lockout (Issue #68)** - [Plan 075](Plans/075-low-battery-lockout.md) ✅ COMPLETE — Two-tier battery warning: iOS early warning at 25% (BLE flag + push notification + red badge), firmware lockout at 20% (full-screen "charge me", timer-only deep sleep with 15-min health checks). Recovery at 25% with hysteresis. Threshold runtime-configurable via `SET BATTERY LOCKOUT THRESHOLD` serial command, persisted in NVS. 9 firmware files + 4 iOS files changed. PRD and IOS-UX-PRD updated.

--- a/Plans/078-introduce-unit-tests.md
+++ b/Plans/078-introduce-unit-tests.md
@@ -1,0 +1,150 @@
+# Testing Strategy for Aquavate
+
+**GitHub Issue:** [#122](https://github.com/bowerhaus/Aquavate/issues/122)
+**Branch:** `introduce-unit-tests`
+
+## Context
+
+Neither the firmware nor the iOS app has any tests. The user wants minimum viable, high-value tests — not comprehensive coverage. The goal is to cover logic that is complex enough to be bug-prone and hard to catch manually.
+
+Issue #120 ("timezone daily reset firing at UTC midnight") is a concrete example of exactly the kind of bug testing should catch. The drink detection, reset timing, and pace calculations are the highest-risk areas.
+
+---
+
+## Firmware Testing
+
+### Current State
+- `firmware/test/` directory exists (`.gitkeep` only)
+- `platformio.ini` already has `test_dir = test` configured
+- No test framework added yet
+- PlatformIO natively supports both on-device (Unity) and native/host tests
+
+### Approach: PlatformIO Native Tests with Unity
+
+Run tests on the development Mac without any hardware. PlatformIO supports a `[env:native]` environment that compiles and runs C++ on the host.
+
+**Pros:**
+- Zero hardware required — runs in seconds locally
+- PlatformIO already configured for it (`test_dir = test`)
+- Unity (the embedded test framework) is trivial to add to `lib_deps`
+- Pure logic modules have no hardware deps — ideal fit
+- Mocking `getCurrentUnixTime()` to test timezone edge cases is trivial
+
+**Cons:**
+- Requires stubbing out ESP32-specific includes (`Arduino.h`, NVS, `RTC_DATA_ATTR`)
+- Need a `[env:native]` build profile in `platformio.ini`
+- Won't catch hardware integration issues (those need the device anyway)
+
+### What to Test
+
+1. **`drinks.cpp` — timezone reset and drink detection** (highest priority)
+   - `getTodayResetTimestamp()` with injected timestamps across timezones
+   - `recalculateDailyTotals()` with records spanning the 4am boundary
+   - `drinksUpdate()` for gulp/pour/refill/drift classification
+   - This module just had a real bug (Issue #120) — tests here would have caught it
+
+2. **`weight.cpp` — outlier removal**
+   - `removeOutliers()` with known sample arrays
+   - No hardware dependency, pure math
+   - Genuinely hard to reason about with outliers at boundaries
+
+3. **`calibration.cpp` — scale factor math**
+   - `calibrationCalculateScaleFactor()` and `calibrationGetWaterWeight()`
+   - Simple linear math but accuracy is critical (±15ml target)
+
+### What to Skip
+
+- `gestures.cpp` — timing-dependent, needs `millis()` mock, lower risk
+- Display, BLE, serial commands, deep sleep, RTC — hardware-only, no unit test value
+- `main.cpp` — glue code, no testable units
+
+---
+
+## iOS App Testing
+
+### Current State
+- Zero XCTest targets or test files
+- `ENABLE_TESTABILITY = YES` already set in the project — ready to go
+- No testing frameworks installed
+
+### Approach: XCTest Unit Tests
+
+Apple's built-in test framework. No dependencies to add, first-class Xcode support, runs in simulator.
+
+### What to Test
+
+1. **`HydrationReminderService` — pace and deficit calculations** (highest priority)
+   - Pure Swift math: daily goal ÷ 15-hour window = hourly pace
+   - `calculateDeficit()` — expected intake by now vs actual
+   - `calculateUrgency()` → Blue/Amber/Red status thresholds
+   - `canSendReminder()` — throttle logic (max 12/day)
+   - Zero CoreBluetooth or HealthKit dependency — no mocking needed
+   - Runs fully in the simulator
+
+2. **`HydrationState` computed properties** (stretch)
+   - `progress`, `isGoalAchieved` — simple but core to UI correctness
+
+### What to Skip
+
+- `BLEManager` — 2,183 lines, deeply coupled to CoreBluetooth, enormous mocking effort for marginal gain
+- `CalibrationManager` — depends on BLEManager protocol
+- UI tests — brittle, slow, low ROI for a hardware-dependent app
+- HealthKit — requires special simulator entitlements
+
+---
+
+## Files to Modify
+
+**Firmware:**
+- `firmware/platformio.ini` — add `[env:native]` + Unity dep
+- `firmware/test/` — create test files here
+- `firmware/src/drinks.cpp` — may need `getCurrentUnixTime()` injectable
+- `firmware/src/weight.cpp` — pure functions, likely no changes needed
+- `firmware/src/calibration.cpp` — pure functions, likely no changes needed
+
+**iOS:**
+- `ios/Aquavate/Aquavate.xcodeproj/` — add XCTest target via Xcode
+- New: `ios/Aquavate/AquavateTests/HydrationReminderServiceTests.swift`
+- `ios/Aquavate/Aquavate/Services/HydrationReminderService.swift` — may need injectable clock for time-based tests
+
+**Documentation:**
+- `CLAUDE.md` — add Firmware Testing and iOS Testing sections with run commands and guidance
+- `AGENTS.md` — add pre-PR testing step to the development workflow
+
+---
+
+## Documentation to Add
+
+### CLAUDE.md — Firmware Testing section (under Firmware Build Commands)
+
+```bash
+# Run firmware unit tests (no hardware required)
+cd firmware
+~/.platformio/penv/bin/platformio test -e native
+```
+
+- Tests cover pure logic modules only — hardware-dependent code (display, BLE, serial, deep sleep, RTC) is tested manually on device
+- When to run: check `firmware/test/` to see what's covered; run tests if your changes touch anything under test
+
+### CLAUDE.md — iOS Testing section (under iOS Build Commands)
+
+```bash
+# Run iOS unit tests (requires simulator)
+cd ios/Aquavate
+xcodebuild test -scheme Aquavate -destination 'platform=iOS Simulator,name=iPhone 17'
+```
+
+- Tests cover pure business logic only — BLE/CoreBluetooth, HealthKit, and UI are tested manually
+- When to run: check `AquavateTests/` to see what's covered; run tests if your changes touch anything under test
+
+### AGENTS.md — pre-PR checklist addition
+
+- Before opening a firmware PR, check `firmware/test/` — if your changes touch anything covered there, run `platformio test -e native`
+- Before opening an iOS PR, check `AquavateTests/` — if your changes touch anything covered there, run the test suite (`Cmd+U` or `xcodebuild test`)
+
+---
+
+## Verification
+
+- Firmware: `cd firmware && ~/.platformio/penv/bin/platformio test -e native` → all pass
+- iOS: `Cmd+U` in Xcode with iPhone 17 simulator → all pass

--- a/firmware/include/drinks.h
+++ b/firmware/include/drinks.h
@@ -139,4 +139,11 @@ float drinksGetBaselineWaterLevel(const CalibrationData& cal);
  */
 void drinksResetBaseline(int32_t adc);
 
+#ifdef UNIT_TEST
+// Inject a custom time source so tests can control getCurrentUnixTime()
+void setTestTimeProvider(uint32_t (*fn)());
+// Reset all static state between tests
+void testResetDrinkState();
+#endif
+
 #endif // DRINKS_H

--- a/firmware/include/weight.h
+++ b/firmware/include/weight.h
@@ -44,4 +44,9 @@ bool weightIsReady();
 // Get default weight measurement config
 WeightConfig weightGetDefaultConfig();
 
+#ifdef UNIT_TEST
+// Expose internal outlier removal for unit testing
+int removeOutliersTest(int32_t* samples, int count, float std_devs, int32_t& new_mean);
+#endif
+
 #endif // WEIGHT_H

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -63,3 +63,19 @@ lib_deps =
     adafruit/Adafruit BusIO@^1.14.0
     zinggjm/GxEPD2@^1.5.0
     adafruit/Adafruit GFX Library@^1.11.0
+
+; Native host tests — pure logic only, no hardware required
+; Run: ~/.platformio/penv/bin/platformio test -e native
+[env:native]
+platform = native
+framework =
+lib_deps =
+test_framework = unity
+build_flags =
+    -Itest/stubs
+    -Itest
+    -Isrc
+    -Iinclude
+    -DUNIT_TEST
+    -std=c++14
+build_src_filter = -<*>

--- a/firmware/src/config.h
+++ b/firmware/src/config.h
@@ -29,7 +29,12 @@
 #define IOS_MODE    1   // Production: BLE + serial commands enabled
 
 // Auto-configure feature flags based on IOS_MODE
-#if IOS_MODE
+#ifdef UNIT_TEST
+    // Native test build — hardware features disabled
+    #define ENABLE_BLE                      0
+    #define ENABLE_SERIAL_COMMANDS          0
+    #define ENABLE_STANDALONE_CALIBRATION   0
+#elif IOS_MODE
     #define ENABLE_BLE                      1
     #define ENABLE_SERIAL_COMMANDS          1   // Both fit in IRAM (~121KB / 131KB)
     #define ENABLE_STANDALONE_CALIBRATION   1   // Bottle-driven calibration (iOS mirrors state)

--- a/firmware/src/drinks.cpp
+++ b/firmware/src/drinks.cpp
@@ -34,7 +34,15 @@ RTC_DATA_ATTR int32_t rtc_last_stable_adc = 0;
 RTC_DATA_ATTR float rtc_last_stable_water_ml = 0.0f;
 
 // Helper: Get current UTC Unix timestamp
+#ifdef UNIT_TEST
+static uint32_t (*s_test_time_fn)() = nullptr;
+void setTestTimeProvider(uint32_t (*fn)()) { s_test_time_fn = fn; }
+#endif
+
 uint32_t getCurrentUnixTime() {
+#ifdef UNIT_TEST
+    if (s_test_time_fn) return s_test_time_fn();
+#endif
     struct timeval tv;
     gettimeofday(&tv, NULL);
     return (uint32_t)tv.tv_sec;  // true UTC; callers add g_timezone_offset as needed
@@ -484,3 +492,16 @@ void drinksResetBaseline(int32_t adc) {
     storageSaveDailyState(g_daily_state);
     DEBUG_PRINTF(g_debug_drink_tracking, "Drinks: Baseline reset to ADC=%d\n", adc);
 }
+
+#ifdef UNIT_TEST
+// Reset all static state so each test starts clean
+void testResetDrinkState() {
+    g_drinks_initialized      = false;
+    g_cached_daily_total_ml   = 0;
+    g_cached_drink_count      = 0;
+    memset(&g_daily_state, 0, sizeof(DailyState));
+    rtc_drinks_magic          = 0;
+    rtc_last_stable_adc       = 0;
+    rtc_last_stable_water_ml  = 0.0f;
+}
+#endif

--- a/firmware/src/weight.cpp
+++ b/firmware/src/weight.cpp
@@ -110,6 +110,13 @@ static int removeOutliers(int32_t* samples, int count, float std_devs, int32_t& 
     return filtered_count;
 }
 
+#ifdef UNIT_TEST
+// Expose static removeOutliers() for direct unit testing
+int removeOutliersTest(int32_t* samples, int count, float std_devs, int32_t& new_mean) {
+    return removeOutliers(samples, count, std_devs, new_mean);
+}
+#endif
+
 WeightMeasurement weightMeasureStable() {
     return weightMeasureStable(weightGetDefaultConfig());
 }

--- a/firmware/test/stubs.cpp
+++ b/firmware/test/stubs.cpp
@@ -1,0 +1,182 @@
+// stubs.cpp — link-time stub implementations for the native test build.
+// Provides: Serial global, all extern globals from main.cpp, all storage/display
+// function stubs, and an in-memory circular buffer that drinks tests can seed.
+//
+// The three source files under test are #included at the bottom of this file.
+// PlatformIO native test mode only compiles test/ files, so the source files
+// must be pulled in here rather than via build_src_filter.
+
+#include "Arduino.h"
+#include "storage.h"
+#include "storage_drinks.h"
+#include "display.h"
+
+// ---------------------------------------------------------------------------
+// Serial global (declared in Arduino.h stub)
+// ---------------------------------------------------------------------------
+SerialClass Serial;
+
+// ---------------------------------------------------------------------------
+// Globals normally defined in main.cpp
+// ---------------------------------------------------------------------------
+bool g_debug_enabled          = false;
+bool g_debug_water_level      = false;
+bool g_debug_accelerometer    = false;
+bool g_debug_display          = false;
+bool g_debug_drink_tracking   = false;
+bool g_debug_calibration      = false;
+bool g_debug_ble              = false;
+uint8_t g_daily_intake_display_mode = 0;
+
+// Accessed by drinks.cpp as extern
+int8_t g_timezone_offset      = 0;
+bool   g_time_valid            = false;
+bool   g_rtc_ds3231_present    = false;
+
+// display.h declares this as extern; the real implementation is in display.cpp
+// (not compiled in the native build) so we provide a placeholder here.
+const unsigned char water_drop_bitmap[] = {0};
+
+// ---------------------------------------------------------------------------
+// Display stubs
+// ---------------------------------------------------------------------------
+void displayNVSWarning() {}
+
+// ---------------------------------------------------------------------------
+// In-memory storage for drinks tests
+// ---------------------------------------------------------------------------
+static CircularBufferMetadata g_stub_meta;
+static DrinkRecord             g_stub_records[30];
+static DailyState              g_stub_daily_state;
+static bool                    g_stub_daily_state_valid = false;
+
+void testClearStorage() {
+    memset(&g_stub_meta, 0, sizeof(g_stub_meta));
+    g_stub_meta.next_record_id = 1;
+    memset(g_stub_records, 0, sizeof(g_stub_records));
+    memset(&g_stub_daily_state, 0, sizeof(g_stub_daily_state));
+    g_stub_daily_state_valid = false;
+}
+
+void testAddDrinkRecord(uint32_t timestamp, int16_t amount_ml, uint8_t flags) {
+    if (g_stub_meta.record_count >= 30) return;
+    int i = g_stub_meta.record_count;
+    g_stub_records[i].record_id      = g_stub_meta.next_record_id++;
+    g_stub_records[i].timestamp      = timestamp;
+    g_stub_records[i].amount_ml      = amount_ml;
+    g_stub_records[i].bottle_level_ml = 0;
+    g_stub_records[i].flags          = flags;
+    g_stub_records[i].type           = (amount_ml >= 100) ? 1 : 0;
+    g_stub_meta.record_count++;
+}
+
+// ---------------------------------------------------------------------------
+// storage_drinks.h stubs
+// ---------------------------------------------------------------------------
+bool storageInitDrinkFS() { return true; }
+
+bool storageLoadBufferMetadata(CircularBufferMetadata& meta) {
+    meta = g_stub_meta;
+    return true;
+}
+
+bool storageSaveBufferMetadata(const CircularBufferMetadata& meta) {
+    g_stub_meta = meta;
+    return true;
+}
+
+bool storageGetDrinkRecord(uint16_t index, DrinkRecord& record) {
+    if (index >= g_stub_meta.record_count || index >= 30) return false;
+    record = g_stub_records[index];
+    return true;
+}
+
+bool storageSaveDrinkRecord(const DrinkRecord& record) {
+    if (g_stub_meta.record_count >= 30) return false;
+    DrinkRecord r = record;
+    r.record_id = g_stub_meta.next_record_id++;
+    g_stub_records[g_stub_meta.write_index % 30] = r;
+    g_stub_meta.write_index++;
+    g_stub_meta.record_count++;
+    g_stub_meta.total_writes++;
+    return true;
+}
+
+bool storageLoadLastDrinkRecord(DrinkRecord& record) {
+    if (g_stub_meta.record_count == 0) return false;
+    record = g_stub_records[g_stub_meta.record_count - 1];
+    return true;
+}
+
+bool storageLoadDailyState(DailyState& state) {
+    if (!g_stub_daily_state_valid) return false;
+    state = g_stub_daily_state;
+    return true;
+}
+
+bool storageSaveDailyState(const DailyState& state) {
+    g_stub_daily_state       = state;
+    g_stub_daily_state_valid = true;
+    return true;
+}
+
+bool storageMarkSynced(uint16_t, uint16_t) { return true; }
+uint16_t storageGetUnsyncedCount()          { return 0; }
+bool storageGetUnsyncedRecords(DrinkRecord*, uint16_t, uint16_t& out_count) {
+    out_count = 0;
+    return true;
+}
+
+bool storageMarkDeleted(uint32_t record_id) {
+    for (uint16_t i = 0; i < g_stub_meta.record_count; i++) {
+        if (g_stub_records[i].record_id == record_id) {
+            g_stub_records[i].flags |= 0x04;
+            return true;
+        }
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// storage.h stubs (NVS-based settings — not exercised in drinks/weight tests)
+// ---------------------------------------------------------------------------
+bool storageInit()                                  { return true; }
+bool storageSaveCalibration(const CalibrationData&) { return true; }
+bool storageLoadCalibration(CalibrationData&)       { return false; }
+bool storageResetCalibration()                      { return true; }
+bool storageHasValidCalibration()                   { return false; }
+
+CalibrationData storageGetEmptyCalibration() {
+    CalibrationData c;
+    memset(&c, 0, sizeof(c));
+    return c;
+}
+
+bool storageSaveTimezone(int8_t)    { return true; }
+int8_t storageLoadTimezone()        { return 0; }
+bool storageSaveTimeValid(bool)     { return true; }
+bool storageLoadTimeValid()         { return false; }
+bool storageSaveLastBootTime(uint32_t) { return true; }
+uint32_t storageLoadLastBootTime()  { return 0; }
+bool storageSaveDisplayMode(uint8_t) { return true; }
+uint8_t storageLoadDisplayMode()    { return 0; }
+bool storageSaveSleepTimeout(uint32_t) { return true; }
+uint32_t storageLoadSleepTimeout()  { return 30; }
+bool storageSaveExtendedSleepTimer(uint32_t) { return true; }
+uint32_t storageLoadExtendedSleepTimer() { return 60; }
+bool storageSaveExtendedSleepThreshold(uint32_t) { return true; }
+uint32_t storageLoadExtendedSleepThreshold() { return 120; }
+bool storageSaveShakeToEmptyEnabled(bool) { return true; }
+bool storageLoadShakeToEmptyEnabled() { return true; }
+bool storageSaveDailyGoal(uint16_t) { return true; }
+uint16_t storageLoadDailyGoal()     { return 2500; }
+bool storageSaveLowBatteryThreshold(uint8_t) { return true; }
+uint8_t storageLoadLowBatteryThreshold() { return 20; }
+
+// ---------------------------------------------------------------------------
+// Source files under test — included here because PlatformIO native test mode
+// only compiles files in test/, not src/.
+// ---------------------------------------------------------------------------
+#include "../src/calibration.cpp"
+#include "../src/weight.cpp"
+#include "../src/drinks.cpp"

--- a/firmware/test/stubs/Adafruit_ADXL343.h
+++ b/firmware/test/stubs/Adafruit_ADXL343.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <stdint.h>
+
+// Sensor event stub (normally from Adafruit_Sensor.h)
+struct sensors_vec_t { float x, y, z; };
+struct sensors_event_t { sensors_vec_t acceleration; };
+
+// Minimal stub so gestures.h / calibration.h compile on the host.
+// gesturesInit() is never called from native tests.
+class Adafruit_ADXL343 {
+public:
+    Adafruit_ADXL343(uint8_t) {}
+    bool begin(uint8_t = 0x53)           { return false; }
+    bool getEvent(sensors_event_t*)      { return false; }
+    void setRange(uint8_t)               {}
+    void setDataRate(uint8_t)            {}
+    void writeRegister(uint8_t, uint8_t) {}
+    uint8_t readRegister(uint8_t)        { return 0; }
+};

--- a/firmware/test/stubs/Adafruit_NAU7802.h
+++ b/firmware/test/stubs/Adafruit_NAU7802.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <stdint.h>
+
+// Minimal stub so weight.h / weight.cpp compile on the host.
+// No method bodies needed — weightMeasureStable() is not called in native tests.
+class Adafruit_NAU7802 {
+public:
+    bool begin()      { return false; }
+    bool available()  { return false; }
+    int32_t read()    { return 0; }
+    void setGain(uint8_t) {}
+    void setSampleRate(uint8_t) {}
+    void calibrate()  {}
+};

--- a/firmware/test/stubs/Adafruit_ThinkInk.h
+++ b/firmware/test/stubs/Adafruit_ThinkInk.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Minimal stub so display.h compiles on the host.
+// No display functions are called from drinks.cpp tests (only displayNVSWarning,
+// which is stubbed in stubs.cpp).
+class ThinkInk_213_Mono_GDEY0213B74 {};

--- a/firmware/test/stubs/Arduino.h
+++ b/firmware/test/stubs/Arduino.h
@@ -1,0 +1,67 @@
+#pragma once
+// Minimal Arduino.h stub for native (host) unit test builds.
+// Provides the types, macros, and Serial interface that firmware code expects,
+// implemented using standard POSIX/C++14 so tests run without any hardware.
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+// ESP32-specific attribute — no-op on host
+#define RTC_DATA_ATTR
+#define PROGMEM
+#define IRAM_ATTR
+
+// Arduino type aliases (stdint already covers uint8_t etc.)
+typedef bool boolean;
+typedef unsigned char byte;
+
+// Minimal String class (used in some headers but not in tested functions)
+class String {
+public:
+    String() {}
+    String(const char*) {}
+    String(int) {}
+};
+
+// Serial stub — routes to stdout so test output is readable
+class SerialClass {
+public:
+    void begin(int) {}
+    void print(const char* s)  { printf("%s", s ? s : "(null)"); }
+    void print(int v)          { printf("%d", v); }
+    void print(long v)         { printf("%ld", v); }
+    void print(float v)        { printf("%f", v); }
+    void print(double v)       { printf("%f", v); }
+    void print(bool v)         { printf("%s", v ? "true" : "false"); }
+    void println(const char* s){ printf("%s\n", s ? s : "(null)"); }
+    void println(int v)        { printf("%d\n", v); }
+    void println(long v)       { printf("%ld\n", v); }
+    void println(float v)      { printf("%f\n", v); }
+    void println(double v)     { printf("%f\n", v); }
+    void println()             { printf("\n"); }
+    void printf(const char* fmt, ...) {
+        va_list args;
+        va_start(args, fmt);
+        vprintf(fmt, args);
+        va_end(args);
+    }
+    void flush() {}
+};
+
+extern SerialClass Serial;
+
+// Timing stubs — not needed for pure logic tests
+inline uint32_t millis() { return 0; }
+inline uint32_t micros() { return 0; }
+inline void delay(unsigned long) {}
+inline void delayMicroseconds(unsigned int) {}
+
+// Math helpers already in <math.h>; these forward to it
+using ::fabs;
+using ::sqrt;
+using ::abs;

--- a/firmware/test/test_calibration/test_calibration.cpp
+++ b/firmware/test/test_calibration/test_calibration.cpp
@@ -1,0 +1,117 @@
+// test_calibration.cpp — unit tests for scale-factor math in calibration.cpp
+//
+// Tests the two pure functions that are always compiled (outside ENABLE_STANDALONE_CALIBRATION):
+//   calibrationCalculateScaleFactor()  — two-point linear calibration
+//   calibrationGetWaterWeight()        — ADC → ml conversion
+//
+// No hardware, no NVS, no BLE required.
+
+#include <unity.h>
+#include "calibration.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ---------------------------------------------------------------------------
+// calibrationCalculateScaleFactor
+// ---------------------------------------------------------------------------
+
+void test_scale_factor_zero_to_full() {
+    // 0..830000 ADC for 830 ml → exactly 1000.0 ADC/g
+    float sf = calibrationCalculateScaleFactor(0, 830000, 830.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 1000.0f, sf);
+}
+
+void test_scale_factor_typical_values() {
+    // Typical NAU7802 range: empty≈1000000, full≈1415000 for 830 ml → ≈500 ADC/g
+    float sf = calibrationCalculateScaleFactor(1000000, 1415000, 830.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 500.0f, sf);
+}
+
+void test_scale_factor_returns_zero_when_full_le_empty() {
+    // full_adc ≤ empty_adc is physically impossible — must return 0 (error sentinel)
+    float sf = calibrationCalculateScaleFactor(1000000, 500000, 830.0f);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, sf);
+}
+
+void test_scale_factor_returns_zero_when_equal() {
+    float sf = calibrationCalculateScaleFactor(500000, 500000, 830.0f);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, sf);
+}
+
+// ---------------------------------------------------------------------------
+// calibrationGetWaterWeight
+// ---------------------------------------------------------------------------
+
+static CalibrationData make_cal(float scale_factor, int32_t empty_adc) {
+    CalibrationData cal;
+    cal.scale_factor       = scale_factor;
+    cal.empty_bottle_adc   = empty_adc;
+    cal.full_bottle_adc    = empty_adc + (int32_t)(scale_factor * 830.0f);
+    cal.calibration_valid  = 1;
+    cal.calibration_timestamp = 0;
+    return cal;
+}
+
+void test_water_weight_at_empty_adc_is_zero() {
+    CalibrationData cal = make_cal(500.0f, 1000000);
+    float ml = calibrationGetWaterWeight(1000000, cal);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, ml);
+}
+
+void test_water_weight_at_full_adc_is_830ml() {
+    CalibrationData cal = make_cal(500.0f, 1000000);
+    // full_adc = 1000000 + 500 * 830 = 1415000
+    float ml = calibrationGetWaterWeight(1415000, cal);
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 830.0f, ml);
+}
+
+void test_water_weight_midpoint() {
+    CalibrationData cal = make_cal(500.0f, 1000000);
+    // halfway: ADC = 1207500 → 415ml
+    float ml = calibrationGetWaterWeight(1207500, cal);
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 415.0f, ml);
+}
+
+void test_water_weight_returns_zero_for_invalid_calibration() {
+    CalibrationData cal = make_cal(500.0f, 1000000);
+    cal.calibration_valid = 0;
+    float ml = calibrationGetWaterWeight(1200000, cal);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, ml);
+}
+
+void test_water_weight_returns_zero_for_zero_scale_factor() {
+    CalibrationData cal = make_cal(0.0f, 1000000);
+    cal.calibration_valid = 1;
+    float ml = calibrationGetWaterWeight(1200000, cal);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, ml);
+}
+
+void test_water_weight_negative_when_below_empty() {
+    // ADC below empty bottle is physically possible (tare error) — should return negative
+    CalibrationData cal = make_cal(500.0f, 1000000);
+    float ml = calibrationGetWaterWeight(900000, cal);
+    TEST_ASSERT_TRUE(ml < 0.0f);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_scale_factor_zero_to_full);
+    RUN_TEST(test_scale_factor_typical_values);
+    RUN_TEST(test_scale_factor_returns_zero_when_full_le_empty);
+    RUN_TEST(test_scale_factor_returns_zero_when_equal);
+
+    RUN_TEST(test_water_weight_at_empty_adc_is_zero);
+    RUN_TEST(test_water_weight_at_full_adc_is_830ml);
+    RUN_TEST(test_water_weight_midpoint);
+    RUN_TEST(test_water_weight_returns_zero_for_invalid_calibration);
+    RUN_TEST(test_water_weight_returns_zero_for_zero_scale_factor);
+    RUN_TEST(test_water_weight_negative_when_below_empty);
+
+    return UNITY_END();
+}

--- a/firmware/test/test_drinks/test_drinks.cpp
+++ b/firmware/test/test_drinks/test_drinks.cpp
@@ -1,0 +1,241 @@
+// test_drinks.cpp — unit tests for timezone reset logic and drink detection
+//
+// Covers the two highest-risk areas:
+//   getSecondsUntilRollover() — timezone boundary math (Issue #120 regression)
+//   drinksUpdate()            — drink / refill / drift classification
+//   recalculateDailyTotals()  — reset boundary filtering via drinksInit()
+//
+// Uses setTestTimeProvider() to inject a fixed UTC timestamp so tests are
+// deterministic regardless of when they run.
+
+#include <unity.h>
+#include <time.h>
+#include "drinks.h"
+#include "calibration.h"
+#include "test_helpers.h"
+
+// ---------------------------------------------------------------------------
+// Known base timestamp: 2024-01-15 00:00:00 UTC (Monday midnight)
+// Verified: date -u -r 1705276800 → Mon Jan 15 00:00:00 UTC 2024
+// ---------------------------------------------------------------------------
+static const uint32_t T_2024_01_15_MIDNIGHT_UTC = 1705276800u;
+
+static uint32_t g_fake_utc = 0;
+static uint32_t fake_time() { return g_fake_utc; }
+
+// Calibration: 500 ADC counts per gram, empty bottle at ADC 0
+// → ADC 250000 = 500 ml, ADC 150000 = 300 ml
+static CalibrationData make_test_cal() {
+    CalibrationData cal;
+    cal.scale_factor        = 500.0f;
+    cal.empty_bottle_adc    = 0;
+    cal.full_bottle_adc     = 415000;
+    cal.calibration_valid   = 1;
+    cal.calibration_timestamp = 0;
+    return cal;
+}
+
+void setUp(void) {
+    // Make mktime() behave as timegm() — matches ESP32 (UTC-only) behaviour
+    setenv("TZ", "UTC", 1);
+    tzset();
+
+    g_timezone_offset = 0;
+    g_time_valid      = true;
+    g_fake_utc        = T_2024_01_15_MIDNIGHT_UTC + 3600u;  // 01:00 UTC default
+
+    setTestTimeProvider(fake_time);
+    testClearStorage();
+    testResetDrinkState();
+}
+
+void tearDown(void) {}
+
+// ---------------------------------------------------------------------------
+// getSecondsUntilRollover — timezone boundary tests
+// These would have caught Issue #120 (UTC midnight fired instead of local midnight)
+// ---------------------------------------------------------------------------
+
+void test_rollover_utc_noon_is_12h_away() {
+    // UTC+0, 12:00 → next midnight is exactly 12 h away
+    g_fake_utc        = T_2024_01_15_MIDNIGHT_UTC + 12u * 3600u;
+    g_timezone_offset = 0;
+    uint32_t secs     = getSecondsUntilRollover();
+    TEST_ASSERT_UINT32_WITHIN(1, 12u * 3600u, secs);
+}
+
+void test_rollover_returns_zero_when_time_invalid() {
+    g_time_valid = false;
+    TEST_ASSERT_EQUAL(0u, getSecondsUntilRollover());
+}
+
+void test_rollover_bst_11pm_local_is_1h_away() {
+    // UTC+1 (BST): 22:00 UTC = 23:00 local → next local midnight is 1h away
+    g_fake_utc        = T_2024_01_15_MIDNIGHT_UTC + 22u * 3600u;
+    g_timezone_offset = 1;
+    uint32_t secs     = getSecondsUntilRollover();
+    TEST_ASSERT_UINT32_WITHIN(1, 3600u, secs);
+}
+
+void test_rollover_bst_midnight_utc_is_23h_away() {
+    // UTC+1: 00:00 UTC = 01:00 local → local midnight was 1h ago
+    // → next local midnight is 23h from now
+    g_fake_utc        = T_2024_01_15_MIDNIGHT_UTC;  // exactly midnight UTC
+    g_timezone_offset = 1;
+    uint32_t secs     = getSecondsUntilRollover();
+    TEST_ASSERT_UINT32_WITHIN(1, 23u * 3600u, secs);
+}
+
+void test_rollover_est_noon_utc_is_12h_away() {
+    // UTC-5 (EST): 12:00 UTC = 07:00 local → next midnight local = 17h from now (05:00 UTC next day)
+    g_fake_utc        = T_2024_01_15_MIDNIGHT_UTC + 12u * 3600u;
+    g_timezone_offset = -5;
+    uint32_t secs     = getSecondsUntilRollover();
+    TEST_ASSERT_UINT32_WITHIN(1, 17u * 3600u, secs);
+}
+
+void test_rollover_one_minute_before_midnight() {
+    // UTC+0, 23:59 → 60 seconds until midnight
+    g_fake_utc        = T_2024_01_15_MIDNIGHT_UTC + 24u * 3600u - 60u;
+    g_timezone_offset = 0;
+    uint32_t secs     = getSecondsUntilRollover();
+    TEST_ASSERT_UINT32_WITHIN(1, 60u, secs);
+}
+
+// ---------------------------------------------------------------------------
+// drinksUpdate — drink / refill / drift classification
+// ---------------------------------------------------------------------------
+
+void test_drink_first_call_establishes_baseline() {
+    CalibrationData cal = make_test_cal();
+    drinksInit();  // sets g_drinks_initialized = true
+    // First call → baseline established, no drink recorded
+    bool result = drinksUpdate(250000, cal);
+    TEST_ASSERT_FALSE(result);
+    TEST_ASSERT_EQUAL(0, drinksGetDailyTotal());
+}
+
+void test_drink_second_call_detects_drink() {
+    CalibrationData cal = make_test_cal();
+    drinksInit();
+    drinksUpdate(250000, cal);          // establish baseline at 500 ml
+
+    bool result = drinksUpdate(150000, cal);  // 300 ml now → delta 200 ml
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL(200, drinksGetDailyTotal());
+}
+
+void test_refill_not_recorded_in_daily_total() {
+    CalibrationData cal = make_test_cal();
+    drinksInit();
+    drinksUpdate(150000, cal);          // baseline at 300 ml
+    bool result = drinksUpdate(400000, cal);  // 800 ml → +500 ml refill
+    TEST_ASSERT_FALSE(result);          // refill returns false
+    TEST_ASSERT_EQUAL(0, drinksGetDailyTotal());
+}
+
+void test_small_delta_below_threshold_not_recorded() {
+    CalibrationData cal = make_test_cal();
+    drinksInit();
+    drinksUpdate(250000, cal);          // baseline at 500 ml
+    // 10 ml decrease — below DRINK_MIN_THRESHOLD_ML (30 ml), not a drink
+    bool result = drinksUpdate(245000, cal);  // 490 ml
+    TEST_ASSERT_FALSE(result);
+    TEST_ASSERT_EQUAL(0, drinksGetDailyTotal());
+}
+
+// ---------------------------------------------------------------------------
+// recalculateDailyTotals — reset boundary filtering
+// ---------------------------------------------------------------------------
+
+void test_daily_total_only_counts_todays_drinks() {
+    // Seed in-memory storage: one record from yesterday, one from today
+    uint32_t yesterday = T_2024_01_15_MIDNIGHT_UTC - 3600u;  // 23:00 UTC Jan 14
+    uint32_t today     = T_2024_01_15_MIDNIGHT_UTC + 1800u;  // 00:30 UTC Jan 15
+
+    testAddDrinkRecord(yesterday, 150, 0);   // should NOT count
+    testAddDrinkRecord(today,     200, 0);   // should count
+
+    g_fake_utc        = T_2024_01_15_MIDNIGHT_UTC + 3600u;  // 01:00 UTC
+    g_timezone_offset = 0;
+    drinksInit();  // recalculateDailyTotals() runs here
+
+    TEST_ASSERT_EQUAL(200, drinksGetDailyTotal());
+    TEST_ASSERT_EQUAL(1,   drinksGetDrinkCount());
+}
+
+void test_daily_total_excludes_deleted_records() {
+    uint32_t today = T_2024_01_15_MIDNIGHT_UTC + 3600u;
+    testAddDrinkRecord(today, 150, 0x04);   // flags=0x04 → deleted
+
+    g_fake_utc        = today + 1800u;
+    g_timezone_offset = 0;
+    drinksInit();
+
+    TEST_ASSERT_EQUAL(0, drinksGetDailyTotal());
+    TEST_ASSERT_EQUAL(0, drinksGetDrinkCount());
+}
+
+void test_daily_total_accumulates_multiple_drinks() {
+    uint32_t base = T_2024_01_15_MIDNIGHT_UTC + 3600u;
+    testAddDrinkRecord(base,          150, 0);
+    testAddDrinkRecord(base + 1800u,  200, 0);
+    testAddDrinkRecord(base + 3600u,  100, 0);
+
+    g_fake_utc        = base + 7200u;
+    g_timezone_offset = 0;
+    drinksInit();
+
+    TEST_ASSERT_EQUAL(450, drinksGetDailyTotal());
+    TEST_ASSERT_EQUAL(3,   drinksGetDrinkCount());
+}
+
+void test_daily_total_bst_counts_correct_day() {
+    // UTC+1 (BST): reset at 23:00 UTC (= local midnight)
+    // Record at 22:00 UTC (= 23:00 BST yesterday) should NOT count
+    // Record at 23:30 UTC (= 00:30 BST today) should count
+    uint32_t before_bst_midnight = T_2024_01_15_MIDNIGHT_UTC - 2u * 3600u; // 22:00 UTC Jan 14
+    uint32_t after_bst_midnight  = T_2024_01_15_MIDNIGHT_UTC - 30u * 60u;  // 23:30 UTC Jan 14
+
+    testAddDrinkRecord(before_bst_midnight, 120, 0);
+    testAddDrinkRecord(after_bst_midnight,  180, 0);
+
+    // Current time: 01:00 UTC Jan 15 = 02:00 BST Jan 15
+    g_fake_utc        = T_2024_01_15_MIDNIGHT_UTC + 3600u;
+    g_timezone_offset = 1;
+    drinksInit();
+
+    // Local midnight BST = 23:00 UTC Jan 14 → 23:30 UTC is after it
+    TEST_ASSERT_EQUAL(180, drinksGetDailyTotal());
+    TEST_ASSERT_EQUAL(1,   drinksGetDrinkCount());
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(void) {
+    UNITY_BEGIN();
+
+    // Rollover / timezone boundary tests
+    RUN_TEST(test_rollover_utc_noon_is_12h_away);
+    RUN_TEST(test_rollover_returns_zero_when_time_invalid);
+    RUN_TEST(test_rollover_bst_11pm_local_is_1h_away);
+    RUN_TEST(test_rollover_bst_midnight_utc_is_23h_away);
+    RUN_TEST(test_rollover_est_noon_utc_is_12h_away);
+    RUN_TEST(test_rollover_one_minute_before_midnight);
+
+    // Drink detection
+    RUN_TEST(test_drink_first_call_establishes_baseline);
+    RUN_TEST(test_drink_second_call_detects_drink);
+    RUN_TEST(test_refill_not_recorded_in_daily_total);
+    RUN_TEST(test_small_delta_below_threshold_not_recorded);
+
+    // Daily total / reset boundary
+    RUN_TEST(test_daily_total_only_counts_todays_drinks);
+    RUN_TEST(test_daily_total_excludes_deleted_records);
+    RUN_TEST(test_daily_total_accumulates_multiple_drinks);
+    RUN_TEST(test_daily_total_bst_counts_correct_day);
+
+    return UNITY_END();
+}

--- a/firmware/test/test_helpers.h
+++ b/firmware/test/test_helpers.h
@@ -1,0 +1,14 @@
+#pragma once
+// Shared declarations for native unit tests.
+// Provides access to globals (normally in main.cpp) and helpers defined in stubs.cpp.
+#include <stdint.h>
+
+// Globals from stubs.cpp (normally defined in main.cpp)
+extern int8_t  g_timezone_offset;
+extern bool    g_time_valid;
+extern bool    g_rtc_ds3231_present;
+extern bool    g_debug_drink_tracking;
+
+// In-memory storage helpers (stubs.cpp)
+void testClearStorage();
+void testAddDrinkRecord(uint32_t timestamp, int16_t amount_ml, uint8_t flags = 0);

--- a/firmware/test/test_weight/test_weight.cpp
+++ b/firmware/test/test_weight/test_weight.cpp
@@ -1,0 +1,96 @@
+// test_weight.cpp — unit tests for outlier removal in weight.cpp
+//
+// Tests removeOutliers() (exposed via removeOutliersTest() under UNIT_TEST)
+// which strips samples more than N standard deviations from the mean.
+//
+// No hardware, no NVS required.
+
+#include <unity.h>
+#include "weight.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ---------------------------------------------------------------------------
+// removeOutliers
+// ---------------------------------------------------------------------------
+
+void test_outlier_removes_single_spike() {
+    int32_t samples[] = {100, 101, 99, 100, 500, 101, 100, 99, 100, 101};
+    int32_t new_mean;
+    int count = removeOutliersTest(samples, 10, 2.0f, new_mean);
+
+    // The 500 spike is > 2 std-devs from the rest — must be removed
+    TEST_ASSERT_LESS_THAN(10, count);
+    // Mean of the clean data should be close to 100
+    TEST_ASSERT_INT_WITHIN(2, 100, new_mean);
+}
+
+void test_outlier_removes_negative_spike() {
+    int32_t samples[] = {100, 101, 99, 100, -400, 101, 100, 99, 100, 101};
+    int32_t new_mean;
+    int count = removeOutliersTest(samples, 10, 2.0f, new_mean);
+
+    TEST_ASSERT_LESS_THAN(10, count);
+    TEST_ASSERT_INT_WITHIN(2, 100, new_mean);
+}
+
+void test_outlier_keeps_uniform_data() {
+    // Symmetric around 1000 so integer mean == 1000 exactly.
+    // Max diff = 1, std_dev ≈ 0.63, threshold ≈ 1.26 → all samples kept.
+    int32_t samples[] = {1000, 1000, 1001, 999, 1000, 1001, 999, 1000, 1000, 1000};
+    int32_t new_mean;
+    int count = removeOutliersTest(samples, 10, 2.0f, new_mean);
+
+    TEST_ASSERT_EQUAL(10, count);
+    TEST_ASSERT_INT_WITHIN(1, 1000, new_mean);
+}
+
+void test_outlier_skips_removal_for_two_samples() {
+    // Need at least 3 samples to apply outlier removal
+    int32_t samples[] = {100, 500};
+    int32_t new_mean;
+    int count = removeOutliersTest(samples, 2, 2.0f, new_mean);
+
+    TEST_ASSERT_EQUAL(2, count);
+}
+
+void test_outlier_skips_removal_for_one_sample() {
+    int32_t samples[] = {999};
+    int32_t new_mean;
+    int count = removeOutliersTest(samples, 1, 2.0f, new_mean);
+
+    TEST_ASSERT_EQUAL(1, count);
+    TEST_ASSERT_EQUAL(999, new_mean);
+}
+
+void test_outlier_tighter_threshold_removes_more() {
+    // With a very tight threshold (0.5 std-devs) even moderate variation is removed
+    int32_t samples[] = {100, 105, 100, 95, 100, 104, 100, 96, 100, 103};
+    int32_t new_mean_tight, new_mean_loose;
+    int32_t s_tight[10], s_loose[10];
+    for (int i = 0; i < 10; i++) { s_tight[i] = s_loose[i] = samples[i]; }
+
+    int count_tight = removeOutliersTest(s_tight, 10, 0.5f, new_mean_tight);
+    int count_loose = removeOutliersTest(s_loose, 10, 3.0f, new_mean_loose);
+
+    // Tighter threshold keeps fewer samples
+    TEST_ASSERT_TRUE(count_tight < count_loose);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_outlier_removes_single_spike);
+    RUN_TEST(test_outlier_removes_negative_spike);
+    RUN_TEST(test_outlier_keeps_uniform_data);
+    RUN_TEST(test_outlier_skips_removal_for_two_samples);
+    RUN_TEST(test_outlier_skips_removal_for_one_sample);
+    RUN_TEST(test_outlier_tighter_threshold_removes_more);
+
+    return UNITY_END();
+}

--- a/ios/Aquavate/Aquavate.xcodeproj/project.pbxproj
+++ b/ios/Aquavate/Aquavate.xcodeproj/project.pbxproj
@@ -11,6 +11,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		19A42E552F9252FF0040A36C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19879E3B2F14429500ED8F60 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 19879E422F14429500ED8F60;
+			remoteInfo = Aquavate;
+		};
 		19FD2D4A2F225FFE00F96E9E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 19879E3B2F14429500ED8F60 /* Project object */;
@@ -36,6 +43,7 @@
 
 /* Begin PBXFileReference section */
 		19879E432F14429500ED8F60 /* Aquavate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Aquavate.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		19A42E512F9252FF0040A36C /* AquavateTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AquavateTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		19FD2D422F225FFC00F96E9E /* AquavateWatch Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AquavateWatch Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -59,6 +67,11 @@
 			path = Aquavate;
 			sourceTree = "<group>";
 		};
+		19A42E522F9252FF0040A36C /* AquavateTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = AquavateTests;
+			sourceTree = "<group>";
+		};
 		19FD2D432F225FFC00F96E9E /* AquavateWatch Watch App */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "AquavateWatch Watch App";
@@ -68,6 +81,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		19879E402F14429500ED8F60 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		19A42E4E2F9252FF0040A36C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -89,6 +109,7 @@
 			children = (
 				19879E452F14429500ED8F60 /* Aquavate */,
 				19FD2D432F225FFC00F96E9E /* AquavateWatch Watch App */,
+				19A42E522F9252FF0040A36C /* AquavateTests */,
 				19879E442F14429500ED8F60 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -98,6 +119,7 @@
 			children = (
 				19879E432F14429500ED8F60 /* Aquavate.app */,
 				19FD2D422F225FFC00F96E9E /* AquavateWatch Watch App.app */,
+				19A42E512F9252FF0040A36C /* AquavateTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -128,6 +150,29 @@
 			productName = Aquavate;
 			productReference = 19879E432F14429500ED8F60 /* Aquavate.app */;
 			productType = "com.apple.product-type.application";
+		};
+		19A42E502F9252FF0040A36C /* AquavateTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 19A42E572F9252FF0040A36C /* Build configuration list for PBXNativeTarget "AquavateTests" */;
+			buildPhases = (
+				19A42E4D2F9252FF0040A36C /* Sources */,
+				19A42E4E2F9252FF0040A36C /* Frameworks */,
+				19A42E4F2F9252FF0040A36C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				19A42E562F9252FF0040A36C /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				19A42E522F9252FF0040A36C /* AquavateTests */,
+			);
+			name = AquavateTests;
+			packageProductDependencies = (
+			);
+			productName = AquavateTests;
+			productReference = 19A42E512F9252FF0040A36C /* AquavateTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		19FD2D412F225FFC00F96E9E /* AquavateWatch Watch App */ = {
 			isa = PBXNativeTarget;
@@ -164,6 +209,10 @@
 					19879E422F14429500ED8F60 = {
 						CreatedOnToolsVersion = 16.2;
 					};
+					19A42E502F9252FF0040A36C = {
+						CreatedOnToolsVersion = 26.2;
+						TestTargetID = 19879E422F14429500ED8F60;
+					};
 					19FD2D412F225FFC00F96E9E = {
 						CreatedOnToolsVersion = 26.2;
 					};
@@ -185,12 +234,20 @@
 			targets = (
 				19879E422F14429500ED8F60 /* Aquavate */,
 				19FD2D412F225FFC00F96E9E /* AquavateWatch Watch App */,
+				19A42E502F9252FF0040A36C /* AquavateTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		19879E412F14429500ED8F60 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		19A42E4F2F9252FF0040A36C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -214,6 +271,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		19A42E4D2F9252FF0040A36C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		19FD2D3E2F225FFC00F96E9E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -224,6 +288,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		19A42E562F9252FF0040A36C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 19879E422F14429500ED8F60 /* Aquavate */;
+			targetProxy = 19A42E552F9252FF0040A36C /* PBXContainerItemProxy */;
+		};
 		19FD2D4B2F225FFE00F96E9E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 19FD2D412F225FFC00F96E9E /* AquavateWatch Watch App */;
@@ -421,6 +490,50 @@
 			};
 			name = Release;
 		};
+		19A42E582F9252FF0040A36C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = S7K2GRB2RN;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bowerhaus.Aquavate.AquavateTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Aquavate.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Aquavate";
+			};
+			name = Debug;
+		};
+		19A42E592F9252FF0040A36C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = S7K2GRB2RN;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bowerhaus.Aquavate.AquavateTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Aquavate.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Aquavate";
+			};
+			name = Release;
+		};
 		19FD2D4E2F225FFE00F96E9E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -504,6 +617,15 @@
 			buildConfigurations = (
 				19879E522F14429B00ED8F60 /* Debug */,
 				19879E532F14429B00ED8F60 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		19A42E572F9252FF0040A36C /* Build configuration list for PBXNativeTarget "AquavateTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				19A42E582F9252FF0040A36C /* Debug */,
+				19A42E592F9252FF0040A36C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Aquavate/Aquavate/Services/HydrationReminderService.swift
+++ b/ios/Aquavate/Aquavate/Services/HydrationReminderService.swift
@@ -59,6 +59,9 @@ class HydrationReminderService: ObservableObject {
 
     weak var notificationManager: NotificationManager?
 
+    // Injectable clock — override in tests for deterministic time
+    var now: () -> Date = { Date() }
+
     // MARK: - Private Properties
 
     private var evaluationTimer: Timer?
@@ -110,10 +113,10 @@ class HydrationReminderService: ObservableObject {
     /// Calculate expected intake based on current time of day
     /// - Returns: Expected ml consumed by now to be on pace
     func calculateExpectedIntake() -> Int {
-        let now = Date()
+        let currentTime = now()
         let calendar = Calendar.current
-        let hour = calendar.component(.hour, from: now)
-        let minute = calendar.component(.minute, from: now)
+        let hour = calendar.component(.hour, from: currentTime)
+        let minute = calendar.component(.minute, from: currentTime)
 
         // Before active hours: expect 0
         if hour < Self.activeHoursStart { return 0 }

--- a/ios/Aquavate/AquavateTests/HydrationReminderServiceTests.swift
+++ b/ios/Aquavate/AquavateTests/HydrationReminderServiceTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import Aquavate
+
+// Tests for HydrationReminderService covering pace, deficit, urgency, and throttle reset.
+//
+// The service is @MainActor so the test class must be too.
+// updateState() internally calls syncStateToWatch() — Watch/AppGroup calls fail
+// silently in test context (no WCSession, no App Group) which is harmless.
+
+@MainActor
+final class HydrationReminderServiceTests: XCTestCase {
+
+    var service: HydrationReminderService!
+
+    override func setUp() {
+        service = HydrationReminderService()
+    }
+
+    override func tearDown() {
+        service = nil  // deinit invalidates the periodic evaluation timer
+    }
+
+    // Build a Date at a specific wall-clock hour using the same calendar the service uses.
+    private func makeDate(hour: Int, minute: Int = 0) -> Date {
+        var comps = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        comps.hour = hour
+        comps.minute = minute
+        comps.second = 0
+        return Calendar.current.date(from: comps)!
+    }
+
+    // MARK: - roundToNearest50
+
+    func testRound_exactMultiple_unchanged() {
+        XCTAssertEqual(HydrationReminderService.roundToNearest50(200), 200)
+    }
+
+    func testRound_justBelow_roundsDown() {
+        XCTAssertEqual(HydrationReminderService.roundToNearest50(224), 200)
+    }
+
+    func testRound_atMidpoint_roundsUp() {
+        XCTAssertEqual(HydrationReminderService.roundToNearest50(225), 250)
+    }
+
+    func testRound_zero_isZero() {
+        XCTAssertEqual(HydrationReminderService.roundToNearest50(0), 0)
+    }
+
+    // MARK: - Pace (calculateExpectedIntake)
+    // Active hours: 7am–10pm (15-hour window); goal = 2500ml default
+
+    func testExpectedIntake_beforeActiveHours_isZero() {
+        service.now = { self.makeDate(hour: 6) }
+        XCTAssertEqual(service.calculateExpectedIntake(), 0)
+    }
+
+    func testExpectedIntake_atActiveHoursStart_isZero() {
+        service.now = { self.makeDate(hour: 7, minute: 0) }
+        XCTAssertEqual(service.calculateExpectedIntake(), 0)
+    }
+
+    func testExpectedIntake_atActiveHoursEnd_isGoal() {
+        service.now = { self.makeDate(hour: 22) }
+        XCTAssertEqual(service.calculateExpectedIntake(), service.dailyGoalMl)
+    }
+
+    func testExpectedIntake_atNoon_isOneThirdOfGoal() {
+        // Noon = 5h into 15h window → 300/900 * 2500 = 833ml (integer division)
+        service.now = { self.makeDate(hour: 12, minute: 0) }
+        let expected = (5 * 60 * service.dailyGoalMl) / (15 * 60)
+        XCTAssertEqual(service.calculateExpectedIntake(), expected)
+    }
+
+    // MARK: - Deficit (calculateDeficit)
+
+    func testDeficit_zeroDrinkAtDayStart_isZero() {
+        // No intake expected before active hours — deficit is 0
+        service.now = { self.makeDate(hour: 7) }
+        // dailyTotalMl is 0 by default; no updateState needed
+        XCTAssertEqual(service.calculateDeficit(), 0)
+    }
+
+    func testDeficit_zeroDrinkAtAfternoon_isPositive() {
+        // 2pm = 7h in → expected ~1167ml; 0 consumed → large positive deficit
+        service.now = { self.makeDate(hour: 14) }
+        XCTAssertGreaterThan(service.calculateDeficit(), 0)
+    }
+
+    // MARK: - Urgency
+
+    func testUrgency_onPaceAtDayStart_isOnTrack() {
+        service.now = { self.makeDate(hour: 7) }
+        service.updateState(totalMl: 0, goalMl: 2500, lastDrink: nil)
+        XCTAssertEqual(service.currentUrgency, .onTrack)
+    }
+
+    func testUrgency_goalAchieved_isOnTrack() {
+        service.now = { self.makeDate(hour: 14) }
+        service.updateState(totalMl: 2500, goalMl: 2500, lastDrink: nil)
+        XCTAssertEqual(service.currentUrgency, .onTrack)
+    }
+
+    func testUrgency_slightlyBehind_isAttention() {
+        // 10am = 3h in → expected = 500ml; 400ml consumed → 100ml deficit
+        // 100ml < 20% threshold (500ml) → attention
+        service.now = { self.makeDate(hour: 10) }
+        service.updateState(totalMl: 400, goalMl: 2500, lastDrink: nil)
+        XCTAssertEqual(service.currentUrgency, .attention)
+    }
+
+    func testUrgency_twentyPercentBehind_isOverdue() {
+        // 2pm = 7h in → expected = 1167ml; 0ml consumed → deficit 1167ml
+        // 1167ml >= 20% of 2500 (500ml) → overdue
+        service.now = { self.makeDate(hour: 14) }
+        service.updateState(totalMl: 0, goalMl: 2500, lastDrink: nil)
+        XCTAssertEqual(service.currentUrgency, .overdue)
+    }
+
+    // MARK: - Throttle reset (checkBackOnTrack)
+    // Verifies that notification state is cleared when urgency improves.
+    // Full escalation-guard testing requires a mock NotificationManager (beyond MVP scope).
+
+    func testBackOnTrack_nilPreviousUrgency_isNoOp() {
+        // Guard in checkBackOnTrack should bail without crashing
+        service.now = { self.makeDate(hour: 14) }
+        service.updateState(totalMl: 0, goalMl: 2500, lastDrink: nil)
+        XCTAssertEqual(service.currentUrgency, .overdue)
+        service.checkBackOnTrack(previousUrgency: nil)
+        // Urgency unchanged (no-op)
+        XCTAssertEqual(service.currentUrgency, .overdue)
+    }
+
+    func testBackOnTrack_overdueToOnTrack_resetsNotifiedUrgency() {
+        // Transition from overdue → onTrack should reset lastNotifiedUrgency to nil
+        service.now = { self.makeDate(hour: 14) }
+        service.updateState(totalMl: 0, goalMl: 2500, lastDrink: nil)
+        XCTAssertEqual(service.currentUrgency, .overdue)
+
+        let previousUrgency = service.currentUrgency
+        service.updateState(totalMl: 2500, goalMl: 2500, lastDrink: Date())
+        XCTAssertEqual(service.currentUrgency, .onTrack)
+
+        service.checkBackOnTrack(previousUrgency: previousUrgency)
+        XCTAssertNil(service.lastNotifiedUrgency)
+    }
+}


### PR DESCRIPTION
## Summary

- **Firmware**: Adds `[env:native]` PlatformIO environment with Unity test framework. Three test suites run on Mac with no hardware required: `test_calibration` (scale-factor math), `test_weight` (outlier removal), `test_drinks` (timezone reset boundary math and drink detection). Injectable `getCurrentUnixTime()` allows deterministic timezone tests — the exact setup that would have caught Issue #120.
- **iOS**: Adds `AquavateTests` XCTest target with `HydrationReminderServiceTests.swift`. Injectable `now: () -> Date` clock on `HydrationReminderService` enables deterministic time-based tests. Covers pace calculation, deficit, urgency thresholds, and throttle reset — 16 tests total.
- **Docs**: `CLAUDE.md` updated with firmware and iOS test run commands and an explicit note not to run iOS tests repeatedly (expensive). `AGENTS.md` updated with pre-PR test checklists for both firmware and iOS.

## Test Results

- Firmware: 30/30 tests green (`platformio test -e native`)
- iOS: 16/16 tests green (`xcodebuild test` on iPhone 17 simulator)

## Documentation

- `CLAUDE.md`: Added `### Firmware Unit Tests` and `### iOS Unit Tests` sections with run commands, when-to-run guidance, and a warning not to run iOS tests more than once per session
- `AGENTS.md`: Added `### Before Opening a Firmware PR` and `### Before Opening an iOS PR` pre-PR checklists

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)